### PR TITLE
[feature] 충전 포인트 지갑 반영 API

### DIFF
--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandService.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandService.java
@@ -2,6 +2,7 @@ package com.trustamarket.walletservice.wallet.application.command;
 
 import java.util.UUID;
 
+import com.trustamarket.walletservice.wallet.application.dto.command.ChargePointCommand;
 import com.trustamarket.walletservice.wallet.application.dto.command.UseWalletCommand;
 import com.trustamarket.walletservice.wallet.application.dto.result.CreateWalletResult;
 import com.trustamarket.walletservice.wallet.application.dto.result.UseWalletResult;
@@ -9,6 +10,7 @@ import com.trustamarket.walletservice.wallet.application.dto.result.UseWalletRes
 public interface WalletCommandService {
 	CreateWalletResult createWallet(UUID userId);
 	UseWalletResult usePoint(UseWalletCommand command);
+	void chargePoint(ChargePointCommand command);
 
 	void transferForSettlement(UUID orderId, UUID sellerId, long totalAmount, long sellerAmount, long feeAmount);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.trustamarket.walletservice.wallet.application.dto.command.ChargePointCommand;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -98,5 +99,15 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 		if (!transactions.isEmpty()) {
 			pointTransactionRepository.saveAll(transactions);
 		}
+	}
+
+	@Override
+	@Transactional
+	public void chargePoint(ChargePointCommand command) {
+		Wallet userWallet = walletRepository.findByUserId(command.userId())
+				.orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
+
+		PointTransaction chargeTx = userWallet.chargePoint(command.chargedAmount(), command.paymentId());
+		walletRepository.save(userWallet);
 	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
@@ -109,5 +109,6 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 
 		PointTransaction chargeTx = userWallet.chargePoint(command.chargedAmount(), command.paymentId());
 		walletRepository.save(userWallet);
+		pointTransactionRepository.save(chargeTx);
 	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/dto/command/ChargePointCommand.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/dto/command/ChargePointCommand.java
@@ -1,0 +1,18 @@
+package com.trustamarket.walletservice.wallet.application.dto.command;
+
+import java.util.UUID;
+
+public record ChargePointCommand (
+    UUID userId,
+    UUID paymentId,
+    long chargedAmount
+) {
+    public ChargePointCommand {
+        if (paymentId == null) {
+            throw new IllegalArgumentException("paymentId는 필수입니다.");
+        }
+        if (chargedAmount <= 0) {
+            throw new IllegalArgumentException("충전 금액은 1원 이상이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/Wallet.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/Wallet.java
@@ -97,6 +97,10 @@ public class Wallet { //createdAt, updatedAt baseEntity 상속
 		return increase(amount, refId, RefType.ORDER, PointTxType.FEE_REVENUE);
 	}
 
+	public PointTransaction chargePoint(long amount, UUID refId) {
+		return increase(amount, refId, RefType.PAYMENT, PointTxType.CHARGE);
+	}
+
 	public PointTransaction increase(long amount, UUID refId, RefType refType, PointTxType txType) {
 		validateActive();
 		if (amount <= 0) {

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRepository.java
@@ -7,4 +7,5 @@ import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
 public interface PointTransactionRepository {
 
 	List<PointTransaction> saveAll(List<PointTransaction> pointTransaction);
+    void save(PointTransaction chargeTx);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
@@ -46,7 +46,7 @@ public class WalletInternalController {
 	}
 
 	@PostMapping("/{userId}/charge")
-	public CommonResponse<Void> chargePoint(@PathVariable UUID userId, @RequestBody ChargedPointRequest request){
+	public CommonResponse<Void> chargePoint(@PathVariable UUID userId, @Valid @RequestBody ChargedPointRequest request){
 		walletCommandService.chargePoint(new ChargePointCommand(userId, request.paymentId(), request.chargedAmount()));
 
 		return new CommonResponse(HttpStatus.OK.value(), null);

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
@@ -2,8 +2,11 @@ package com.trustamarket.walletservice.wallet.presentation;
 
 import java.util.UUID;
 
+import com.trustamarket.walletservice.wallet.application.dto.command.ChargePointCommand;
+import com.trustamarket.walletservice.wallet.presentation.dto.request.ChargedPointRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,5 +43,12 @@ public class WalletInternalController {
 		UseWalletResult result = walletCommandService.usePoint(new UseWalletCommand(request.orderId(), request.buyerId(), request.totalAmount()));
 
 		return new CommonResponse(HttpStatus.OK.value(), new UseWalletResponse(result.balance(), result.shortage()));
+	}
+
+	@PostMapping("/{userId}/charge")
+	public CommonResponse<Void> chargePoint(@PathVariable UUID userId, @RequestBody ChargedPointRequest request){
+		walletCommandService.chargePoint(new ChargePointCommand(userId, request.paymentId(), request.chargedAmount()));
+
+		return new CommonResponse(HttpStatus.OK.value(), null);
 	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/ChargedPointRequest.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/ChargedPointRequest.java
@@ -1,0 +1,11 @@
+package com.trustamarket.walletservice.wallet.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.UUID;
+
+public record ChargedPointRequest (
+    @NotNull UUID paymentId,
+    @Positive long chargedAmount
+) {}


### PR DESCRIPTION
## 🌱 설명

- payment에서 충전금액 결제 후 wallet에 충전금액만큼 포인트 증가

## 📌 관련 이슈

close #11 

## ✅ 주요 변경 사항

- 결제한 금액만큼 충전금액 증가

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

이후에 userId 수정 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 지갑에 포인트 충전 기능이 추가되었습니다.
  * 결제 ID와 충전 금액을 받아 충전 처리 및 거래 기록 생성이 지원됩니다.
  * 입력 유효성(결제 ID 필수, 충전 금액 양수) 검증이 적용되어 잘못된 요청을 차단합니다.
  * 내부 API 엔드포인트로 충전 요청을 수신하고 표준 응답을 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->