### PR TITLE
feat: get wallet info

### DIFF
--- a/src/main/java/com/trustamarket/walletservice/wallet/application/dto/query/GetPointTransactionQuery.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/dto/query/GetPointTransactionQuery.java
@@ -1,0 +1,22 @@
+package com.trustamarket.walletservice.wallet.application.dto.query;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record GetPointTransactionQuery(
+	Instant from,
+	Instant to,
+	Instant cursorTime,
+	UUID cursorId,
+	Integer size
+) {
+	public static GetPointTransactionQuery of(
+		Instant from,
+		Instant to,
+		Instant cursorTime,
+		UUID cursorId,
+		Integer size
+	) {
+		return new GetPointTransactionQuery(from, to, cursorTime, cursorId, size);
+	}
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/dto/result/GetPointTransactionPageResult.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/dto/result/GetPointTransactionPageResult.java
@@ -16,16 +16,17 @@ public record GetPointTransactionPageResult(
 	UUID nextCursorId
 ) {
 	public static GetPointTransactionPageResult from(Slice<PointTransaction> slice) {
-		List<GetPointTransactionResponse> content = slice.getContent().stream()
+		List<PointTransaction> txContent = slice.getContent();
+
+		List<GetPointTransactionResponse> content = txContent.stream()
 			.map(GetPointTransactionResponse::from)
 			.toList();
 
 		Instant nextCursorTime = null;
 		UUID nextCursorId = null;
-
-		if (slice.hasNext() && !slice.getContent().isEmpty()) {
-			PointTransaction last = slice.getContent()
-				.get(slice.getContent().size() - 1);
+		
+		if (slice.hasNext() && !txContent.isEmpty()) {
+			PointTransaction last = txContent.getLast();
 			nextCursorTime = last.getCreatedAt();
 			nextCursorId = last.getPointTransactionId();
 		}
@@ -45,7 +46,7 @@ public record GetPointTransactionPageResult(
 		public static GetPointTransactionResponse from(PointTransaction pointTransaction) {
 			return new GetPointTransactionResponse(
 				pointTransaction.getPointTransactionId(),
-				pointTransaction.getUsePoint(),
+				pointTransaction.getChangeAmount(),
 				pointTransaction.getPointTxType(),
 				pointTransaction.getCreatedAt()
 			);

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/dto/result/GetPointTransactionPageResult.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/dto/result/GetPointTransactionPageResult.java
@@ -1,0 +1,54 @@
+package com.trustamarket.walletservice.wallet.application.dto.result;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Slice;
+
+import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
+import com.trustamarket.walletservice.wallet.domain.enums.PointTxType;
+
+public record GetPointTransactionPageResult(
+	List<GetPointTransactionResponse> content,
+	boolean hasNext,
+	Instant nextCursorTime,
+	UUID nextCursorId
+) {
+	public static GetPointTransactionPageResult from(Slice<PointTransaction> slice) {
+		List<GetPointTransactionResponse> content = slice.getContent().stream()
+			.map(GetPointTransactionResponse::from)
+			.toList();
+
+		Instant nextCursorTime = null;
+		UUID nextCursorId = null;
+
+		if (slice.hasNext() && !slice.getContent().isEmpty()) {
+			PointTransaction last = slice.getContent()
+				.get(slice.getContent().size() - 1);
+			nextCursorTime = last.getCreatedAt();
+			nextCursorId = last.getPointTransactionId();
+		}
+
+		return new GetPointTransactionPageResult(
+			content, slice.hasNext(), nextCursorTime, nextCursorId
+		);
+	}
+
+
+	public record GetPointTransactionResponse (
+		UUID pointTxId,
+		long amount,
+		PointTxType pointTxType,
+		Instant createdAt
+	) {
+		public static GetPointTransactionResponse from(PointTransaction pointTransaction) {
+			return new GetPointTransactionResponse(
+				pointTransaction.getPointTransactionId(),
+				pointTransaction.getUsePoint(),
+				pointTransaction.getPointTxType(),
+				pointTransaction.getCreatedAt()
+			);
+		}
+	}
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryService.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryService.java
@@ -1,0 +1,12 @@
+package com.trustamarket.walletservice.wallet.application.query;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.trustamarket.walletservice.wallet.application.dto.query.GetPointTransactionQuery;
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointTransactionPageResult;
+
+public interface WalletQueryService {
+	long getPoint(UUID userId);
+	GetPointTransactionPageResult getPointTransactions(UUID userId, GetPointTransactionQuery query);
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryServiceImpl.java
@@ -1,0 +1,62 @@
+package com.trustamarket.walletservice.wallet.application.query;
+
+import static com.trustamarket.walletservice.wallet.domain.exception.WalletErrorCode.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.trustamarket.walletservice.wallet.application.dto.query.GetPointTransactionQuery;
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointTransactionPageResult;
+import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
+import com.trustamarket.walletservice.wallet.domain.entity.Wallet;
+import com.trustamarket.walletservice.wallet.domain.exception.WalletException;
+import com.trustamarket.walletservice.wallet.domain.repository.PointTransactionRepository;
+import com.trustamarket.walletservice.wallet.domain.repository.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class WalletQueryServiceImpl implements WalletQueryService{
+	private final WalletRepository walletRepository;
+	private final PointTransactionRepository pointTransactionRepository;
+
+	@Transactional(readOnly = true)
+	public long getPoint(UUID userId) {
+		Wallet wallet = walletRepository.findByUserId(userId).orElseThrow(
+			() -> new WalletException(WALLET_NOT_FOUND)
+		); // 추후 findAllByUserId 고려
+		return wallet.checkBalance();
+	}
+
+	@Transactional(readOnly = true)
+	public GetPointTransactionPageResult getPointTransactions(UUID userId, GetPointTransactionQuery query) {
+		Wallet wallet = walletRepository.findByUserId(userId).orElseThrow(
+			() -> new WalletException(WALLET_NOT_FOUND)
+		);
+		UUID walletId = wallet.getWalletId();
+		UUID cursorId = query.cursorId();
+		Instant cursorTime = query.cursorTime();
+		Instant to = query.to();
+		Instant from = query.from();
+		int size = query.size();
+
+		Slice<PointTransaction> pointTransactions;
+
+		if (cursorId == null) {
+			pointTransactions = pointTransactionRepository.findFirstPointTransactions(
+				walletId, from, to, Pageable.ofSize(size)
+			);
+		} else {
+			pointTransactions = pointTransactionRepository.findNextPointTransactions(
+				walletId, from, to, cursorTime, cursorId, Pageable.ofSize(size)
+			);
+		}
+		return GetPointTransactionPageResult.from(pointTransactions);
+	}
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryServiceImpl.java
@@ -26,6 +26,8 @@ public class WalletQueryServiceImpl implements WalletQueryService{
 	private final WalletRepository walletRepository;
 	private final PointTransactionRepository pointTransactionRepository;
 
+	private static final int DEFAULT_PAGE_SIZE = 20;
+
 	@Transactional(readOnly = true)
 	public long getPoint(UUID userId) {
 		Wallet wallet = walletRepository.findByUserId(userId).orElseThrow(
@@ -44,11 +46,11 @@ public class WalletQueryServiceImpl implements WalletQueryService{
 		Instant cursorTime = query.cursorTime();
 		Instant to = query.to();
 		Instant from = query.from();
-		int size = query.size();
+		int size = query.size() != null ? query.size() : DEFAULT_PAGE_SIZE;
 
 		Slice<PointTransaction> pointTransactions;
 
-		if (cursorId == null) {
+		if (cursorId == null || cursorTime == null) {
 			pointTransactions = pointTransactionRepository.findFirstPointTransactions(
 				walletId, from, to, Pageable.ofSize(size)
 			);

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/BalanceChange.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/BalanceChange.java
@@ -4,7 +4,7 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 record BalanceChange (
-	long balance,
+	long amount,
 	long balanceAfter
 ) {
 	BalanceChange {
@@ -15,10 +15,10 @@ record BalanceChange (
 		}
 	}
 
-	static BalanceChange of(long balanceBefore, long balance) {
+	static BalanceChange of(long balanceBefore, long amount) {
 		try {
-			long balanceAfter = Math.addExact(balanceBefore, balance);
-			return new BalanceChange(balance, balanceAfter);
+			long balanceAfter = Math.addExact(balanceBefore, amount);
+			return new BalanceChange(amount, balanceAfter);
 		} catch (ArithmeticException e) {
 			throw new IllegalStateException("포인트 계산 중 오버플로우 발생");
 		}

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransaction.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransaction.java
@@ -1,10 +1,8 @@
 package com.trustamarket.walletservice.wallet.domain.entity;
 
-import java.time.Instant;
 import java.util.UUID;
 
 import com.trustamarket.common.domain.BaseCreatedEntity;
-import com.trustamarket.common.domain.BaseTimeEntity;
 import com.trustamarket.walletservice.wallet.domain.enums.PointTxType;
 import com.trustamarket.walletservice.wallet.domain.enums.RefType;
 
@@ -81,7 +79,7 @@ public class PointTransaction extends BaseCreatedEntity {
 		}
 	}
 
-	public long getUsePoint() {
+	public long getChangeAmount() {
 		return this.balanceChange.amount();
 	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransaction.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransaction.java
@@ -3,6 +3,8 @@ package com.trustamarket.walletservice.wallet.domain.entity;
 import java.time.Instant;
 import java.util.UUID;
 
+import com.trustamarket.common.domain.BaseCreatedEntity;
+import com.trustamarket.common.domain.BaseTimeEntity;
 import com.trustamarket.walletservice.wallet.domain.enums.PointTxType;
 import com.trustamarket.walletservice.wallet.domain.enums.RefType;
 
@@ -19,14 +21,16 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_point_transactions")
 @Entity
-public class PointTransaction {
+public class PointTransaction extends BaseCreatedEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
+	@Getter
 	private UUID pointTransactionId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -39,11 +43,10 @@ public class PointTransaction {
 	@Embedded
 	private BalanceChange balanceChange;
 
+	@Getter
 	@Enumerated(EnumType.STRING)
 	@Column(name = "tx_type", nullable = false)
 	private PointTxType pointTxType;
-
-	private Instant createdAt;
 
 	public static PointTransaction create(
 		Wallet wallet,
@@ -78,4 +81,7 @@ public class PointTransaction {
 		}
 	}
 
+	public long getUsePoint() {
+		return this.balanceChange.amount();
+	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRepository.java
@@ -1,11 +1,19 @@
 package com.trustamarket.walletservice.wallet.domain.repository;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
 
 public interface PointTransactionRepository {
-
 	List<PointTransaction> saveAll(List<PointTransaction> pointTransaction);
 	PointTransaction save(PointTransaction chargeTx);
+
+	Slice<PointTransaction> findFirstPointTransactions(UUID walletId, Instant from, Instant to, Pageable pageable);
+	Slice<PointTransaction> findNextPointTransactions(UUID walletId, Instant from, Instant to, Instant cursorTime, UUID cursorId, Pageable pageable);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRepositoryImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRepositoryImpl.java
@@ -1,8 +1,13 @@
 package com.trustamarket.walletservice.wallet.infrastructure.persistence;
 
 import java.awt.*;
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
@@ -24,5 +29,17 @@ public class PointTransactionRepositoryImpl implements PointTransactionRepositor
 	@Override
 	public PointTransaction save(PointTransaction chargeTx) {
 		return pointTransactionRepository.save(chargeTx);
+	}
+
+	@Override
+	public Slice<PointTransaction> findFirstPointTransactions(UUID walletId, Instant from, Instant to, Pageable pageable) {
+		return  pointTransactionRepository.findFirstPointTransactions(walletId, from, to, pageable);
+	}
+
+	@Override
+	public Slice<PointTransaction> findNextPointTransactions(
+		UUID walletId, Instant from, Instant to,
+		Instant cursorTime, UUID cursorId, Pageable pageable) {
+		return  pointTransactionRepository.findNextPointTransactions(walletId, from, to, cursorTime, cursorId, pageable);
 	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRepositoryImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRepositoryImpl.java
@@ -1,11 +1,9 @@
 package com.trustamarket.walletservice.wallet.infrastructure.persistence;
 
-import java.awt.*;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionJpaRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionJpaRepository.java
@@ -1,10 +1,38 @@
 package com.trustamarket.walletservice.wallet.infrastructure.persistence.jpa;
 
+import java.time.Instant;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
 
 public interface PointTransactionJpaRepository extends JpaRepository<PointTransaction, UUID> {
+	@Query("""
+		SELECT t FROM PointTransaction t
+		WHERE t.wallet.walletId = :walletId
+		  AND t.createdAt >= :from
+		  AND t.createdAt <= :to
+		ORDER BY t.createdAt DESC, t.pointTransactionId DESC
+	""")
+	Slice<PointTransaction> findFirstPointTransactions(
+		UUID walletId, Instant from, Instant to, Pageable pageable
+	);
+
+	@Query("""
+		SELECT t FROM PointTransaction t
+		WHERE t.wallet.walletId = :walletId
+		  AND t.createdAt >= :from
+		  AND t.createdAt <= :to
+		  AND (t.createdAt < :cursorTime
+			   OR (t.createdAt = :cursorTime AND t.pointTransactionId < :cursorId))
+		ORDER BY t.createdAt DESC, t.pointTransactionId DESC
+	""")
+	Slice<PointTransaction> findNextPointTransactions(
+		UUID walletId, Instant from, Instant to,
+		Instant cursorTime, UUID cursorId, Pageable pageable
+	);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionJpaRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
 
@@ -19,7 +20,10 @@ public interface PointTransactionJpaRepository extends JpaRepository<PointTransa
 		ORDER BY t.createdAt DESC, t.pointTransactionId DESC
 	""")
 	Slice<PointTransaction> findFirstPointTransactions(
-		UUID walletId, Instant from, Instant to, Pageable pageable
+		@Param("walletId") UUID walletId,
+		@Param("from") Instant from,
+		@Param("to") Instant to,
+		Pageable pageable
 	);
 
 	@Query("""
@@ -32,7 +36,11 @@ public interface PointTransactionJpaRepository extends JpaRepository<PointTransa
 		ORDER BY t.createdAt DESC, t.pointTransactionId DESC
 	""")
 	Slice<PointTransaction> findNextPointTransactions(
-		UUID walletId, Instant from, Instant to,
-		Instant cursorTime, UUID cursorId, Pageable pageable
+		@Param("walletId") UUID walletId,
+		@Param("from") Instant from,
+		@Param("to") Instant to,
+		@Param("cursorTime") Instant cursorTime,
+		@Param("cursorId") UUID cursorId,
+		Pageable pageable
 	);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletController.java
@@ -10,6 +10,10 @@ import com.trustamarket.walletservice.wallet.application.dto.result.ChargePointR
 import com.trustamarket.walletservice.wallet.domain.entity.Wallet;
 import com.trustamarket.walletservice.wallet.presentation.dto.request.ChargePointRequest;
 import com.trustamarket.walletservice.wallet.presentation.dto.request.CreateSystemWalletRequest;
+import com.trustamarket.walletservice.wallet.application.dto.query.GetPointTransactionQuery;
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointTransactionPageResult;
+import com.trustamarket.walletservice.wallet.application.query.WalletQueryService;
+import com.trustamarket.walletservice.wallet.presentation.dto.request.GetPointTransactionsRequest;
 import com.trustamarket.walletservice.wallet.presentation.dto.response.ChargePointResponse;
 import com.trustamarket.walletservice.wallet.presentation.dto.response.CreateWalletResponse;
 
@@ -17,6 +21,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +36,7 @@ import java.util.UUID;
 public class WalletController {
 	private final WalletCommandService walletCommandService;
 	private final SystemWalletCommandService systemWalletService;
+	private final WalletQueryService walletQueryService;
 
 	@PostMapping("/charges")
 	public CommonResponse<ChargePointResponse> chargePoint(@Valid @RequestBody ChargePointRequest request){
@@ -42,6 +49,28 @@ public class WalletController {
 		ChargePointResponse response = ChargePointResponse.from(result);
 
 		return new CommonResponse(HttpStatus.OK.value(), response);
+	}
+
+	@GetMapping("/transactions")
+	public CommonResponse<GetPointTransactionPageResult> getPointTransactions(
+		@Valid @ModelAttribute GetPointTransactionsRequest queryRequest
+	) {
+		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
+		GetPointTransactionPageResult result = walletQueryService.getPointTransactions(
+			userId,
+			GetPointTransactionQuery.of(
+				queryRequest.getValidFrom(), queryRequest.getValidTo(),
+				queryRequest.cursorTime(), queryRequest.cursorId(),
+				queryRequest.size())
+		);
+		return new CommonResponse(HttpStatus.OK.value(), result);
+	}
+
+	@GetMapping("/balances")
+	public CommonResponse<Long> getPointBalance() {
+		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
+		long balance = walletQueryService.getPoint(userId);
+		return new CommonResponse(HttpStatus.OK.value(), balance);
 	}
 
 	@PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletController.java
@@ -63,14 +63,14 @@ public class WalletController {
 				queryRequest.cursorTime(), queryRequest.cursorId(),
 				queryRequest.size())
 		);
-		return new CommonResponse(HttpStatus.OK.value(), result);
+		return new CommonResponse<>(HttpStatus.OK.value(), result);
 	}
 
 	@GetMapping("/balances")
 	public CommonResponse<Long> getPointBalance() {
 		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
 		long balance = walletQueryService.getPoint(userId);
-		return new CommonResponse(HttpStatus.OK.value(), balance);
+		return new CommonResponse<>(HttpStatus.OK.value(), balance);
 	}
 
 	@PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/GetPointTransactionsRequest.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/GetPointTransactionsRequest.java
@@ -18,12 +18,13 @@ public record GetPointTransactionsRequest(
 ) {
 	public GetPointTransactionsRequest {
 		if (size == null) size = 20;
-		if (!from.isAfter(to)) {
-			throw new IllegalArgumentException("to가 더 최근이여야 함");
-		}
+
 		to = getValidTo();
 		from = getValidFrom();
 
+		if (!from.isAfter(to)) {
+			throw new IllegalArgumentException("to가 더 최근이여야 함");
+		}
 		if(!isValidCursor()) {
 			throw new IllegalArgumentException("cursor가 맞지 않음");
 		}

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/GetPointTransactionsRequest.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/GetPointTransactionsRequest.java
@@ -1,0 +1,43 @@
+package com.trustamarket.walletservice.wallet.presentation.dto.request;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record GetPointTransactionsRequest(
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant cursorTime,
+	UUID cursorId,
+	@Min(1) @Max(100) Integer size
+) {
+	public GetPointTransactionsRequest {
+		if (size == null) size = 20;
+		if (!from.isAfter(to)) {
+			throw new IllegalArgumentException("to가 더 최근이여야 함");
+		}
+		to = getValidTo();
+		from = getValidFrom();
+
+		if(!isValidCursor()) {
+			throw new IllegalArgumentException("cursor가 맞지 않음");
+		}
+	}
+
+	public Instant getValidTo() {
+		return to != null ? to : Instant.now();
+	}
+
+	public Instant getValidFrom() {
+		return from != null ? from : getValidTo().minus(30, ChronoUnit.DAYS);
+	}
+
+	public boolean isValidCursor() {
+		return (cursorTime == null) == (cursorId == null);
+	}
+}

--- a/src/test/java/com/trustamarket/walletservice/application/query/PointTransactionQueryServiceIntegrationTest.java
+++ b/src/test/java/com/trustamarket/walletservice/application/query/PointTransactionQueryServiceIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.trustamarket.walletservice.application.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.trustamarket.walletservice.wallet.application.dto.query.GetPointTransactionQuery;
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointTransactionPageResult;
+import com.trustamarket.walletservice.wallet.application.query.WalletQueryService;
+import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
+import com.trustamarket.walletservice.wallet.domain.entity.Wallet;
+import com.trustamarket.walletservice.wallet.domain.repository.PointTransactionRepository;
+import com.trustamarket.walletservice.wallet.domain.repository.WalletRepository;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PointTransactionQueryServiceIntegrationTest {
+
+	@Autowired
+	private WalletQueryService walletQueryService;
+	@Autowired
+	private WalletRepository walletRepository;
+	@Autowired
+	private PointTransactionRepository pointTransactionRepository;
+	@Autowired private EntityManager entityManager;
+
+	/*
+		현실적으로 같은 마이크로초에 거래가 발생하긴 어려우니
+		연속된 짧은 시간에 발생한 거래들이 페이지 경계로 확인
+		todo: controller test에서 확실히 데이터 넣어두고 test 추가 진행
+	 */
+	@Test
+	@DisplayName("연속된 거래가 페이지 경계에 걸쳐도 중복 없이 조회 test")
+	void consecutiveTransactions_noDuplicationAcrossPages() {
+		UUID userId = UUID.randomUUID();
+		Wallet wallet = walletRepository.save(Wallet.createUserWallet(userId));
+
+		// 거래 5개 저장 (createdAt은 자동으로 현재 시각으로 찍힘)
+		Set<UUID> createdIds = new HashSet<>();
+		for (int i = 0; i < 5; i++) {
+			PointTransaction tx = pointTransactionRepository.save(
+				wallet.chargeComplete(1000L * (i + 1), UUID.randomUUID())
+			);
+			createdIds.add(tx.getPointTransactionId());
+		}
+		entityManager.flush();
+		entityManager.clear();
+
+		// 거래 시각이 현재 시각이니까 from/to도 현재 시각 기준
+		Instant from = Instant.now().minusSeconds(3600);
+		Instant to = Instant.now().plusSeconds(3600);
+
+		Set<UUID> seen = new HashSet<>();
+		Instant cursorTime = null;
+		UUID cursorId = null;
+
+		while (true) {
+			GetPointTransactionPageResult page = walletQueryService.getPointTransactions(
+				userId,
+				GetPointTransactionQuery.of(from, to, cursorTime, cursorId, 2)
+			);
+
+			for (var tx : page.content()) {
+				assertThat(seen).doesNotContain(tx.pointTxId())
+					.as("페이지 간 중복 발생: " + tx.pointTxId());
+				seen.add(tx.pointTxId());
+			}
+
+			if (!page.hasNext()) break;
+			cursorTime = page.nextCursorTime();
+			cursorId = page.nextCursorId();
+		}
+
+		assertThat(seen).containsExactlyInAnyOrderElementsOf(createdIds);
+	}
+}

--- a/src/test/java/com/trustamarket/walletservice/application/query/PointTransactionQueryServiceIntegrationTest.java
+++ b/src/test/java/com/trustamarket/walletservice/application/query/PointTransactionQueryServiceIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.trustamarket.walletservice.application.query;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mockStatic;
+import static org.assertj.core.api.Assertions.*;
 
 import java.time.Instant;
 import java.util.HashSet;
@@ -10,7 +9,6 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -26,7 +24,7 @@ import com.trustamarket.walletservice.wallet.domain.repository.WalletRepository;
 
 import jakarta.persistence.EntityManager;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @ActiveProfiles("test")
 @Transactional
 class PointTransactionQueryServiceIntegrationTest {
@@ -76,8 +74,9 @@ class PointTransactionQueryServiceIntegrationTest {
 			);
 
 			for (var tx : page.content()) {
-				assertThat(seen).doesNotContain(tx.pointTxId())
-					.as("페이지 간 중복 발생: " + tx.pointTxId());
+				assertThat(seen)
+					.as("페이지 간 중복 발생: " + tx.pointTxId())
+					.doesNotContain(tx.pointTxId());
 				seen.add(tx.pointTxId());
 			}
 

--- a/src/test/java/com/trustamarket/walletservice/application/query/PointTransactionQueryServiceTest.java
+++ b/src/test/java/com/trustamarket/walletservice/application/query/PointTransactionQueryServiceTest.java
@@ -5,10 +5,8 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -131,7 +129,7 @@ class PointTransactionQueryServiceTest {
 		PointTransaction tx = mock(PointTransaction.class);
 		when(tx.getPointTransactionId()).thenReturn(id);
 		when(tx.getCreatedAt()).thenReturn(createdAt);
-		when(tx.getUsePoint()).thenReturn(amount);
+		when(tx.getChangeAmount()).thenReturn(amount);
 		when(tx.getPointTxType()).thenReturn(pointTxType);
 		return tx;
 	}

--- a/src/test/java/com/trustamarket/walletservice/application/query/PointTransactionQueryServiceTest.java
+++ b/src/test/java/com/trustamarket/walletservice/application/query/PointTransactionQueryServiceTest.java
@@ -1,0 +1,138 @@
+package com.trustamarket.walletservice.application.query;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import com.trustamarket.walletservice.wallet.application.dto.query.GetPointTransactionQuery;
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointTransactionPageResult;
+import com.trustamarket.walletservice.wallet.application.query.WalletQueryServiceImpl;
+import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
+import com.trustamarket.walletservice.wallet.domain.entity.Wallet;
+import com.trustamarket.walletservice.wallet.domain.enums.PointTxType;
+import com.trustamarket.walletservice.wallet.domain.exception.WalletException;
+import com.trustamarket.walletservice.wallet.domain.repository.PointTransactionRepository;
+import com.trustamarket.walletservice.wallet.domain.repository.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PointTransactionQueryServiceTest {
+
+	@Mock
+	private WalletRepository walletRepository;
+
+	@Mock
+	private PointTransactionRepository pointTransactionRepository;
+
+	@InjectMocks
+	private WalletQueryServiceImpl queryService;
+
+	@Test
+	@DisplayName("첫 조회면 findFirstPointTransactions를 호출해 거래내역을 반환한다")
+	void getPointTransactions_withoutCursor_callsFirstQuery() {
+		UUID userId = UUID.randomUUID();
+		Wallet wallet = Wallet.createUserWallet(userId);
+		Instant now = Instant.now();
+
+		PointTransaction tx1 = mockTransaction(UUID.randomUUID(), now, 3000L, PointTxType.CHARGE);
+		PointTransaction tx2 = mockTransaction(UUID.randomUUID(), now.minusSeconds(60), 2000L, PointTxType.CHARGE);
+
+		Slice<PointTransaction> slice = new SliceImpl<>(List.of(tx1, tx2), PageRequest.of(0, 2), true);
+
+		when(walletRepository.findByUserId(userId)).thenReturn(Optional.of(wallet));
+		when(pointTransactionRepository.findFirstPointTransactions(
+			eq(wallet.getWalletId()), isNull(), isNull(), any()))
+			.thenReturn(slice);
+
+		GetPointTransactionPageResult result = queryService.getPointTransactions(
+			userId,
+			GetPointTransactionQuery.of(null, null, null, null, 2)
+		);
+
+		assertThat(result.content()).hasSize(2);
+		assertThat(result.content().get(0).amount()).isEqualTo(3000L);
+		assertThat(result.content().get(1).amount()).isEqualTo(2000L);
+		assertThat(result.hasNext()).isTrue();
+		assertThat(result.nextCursorId()).isEqualTo(tx2.getPointTransactionId());
+		assertThat(result.nextCursorTime()).isEqualTo(tx2.getCreatedAt());
+
+		verify(pointTransactionRepository, times(1))
+			.findFirstPointTransactions(eq(wallet.getWalletId()), isNull(), isNull(), any());
+		verify(pointTransactionRepository, never())
+			.findNextPointTransactions(any(), any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("커서가 있으면 findNextPointTransactions를 호출한다")
+	void getPointTransactions_withCursor_callsNextQuery() {
+		UUID userId = UUID.randomUUID();
+		Wallet wallet = Wallet.createUserWallet(userId);
+		Instant cursorTime = Instant.now().minusSeconds(300);
+		UUID cursorId = UUID.randomUUID();
+		Instant from = Instant.now().minusSeconds(3600);
+		Instant to = Instant.now();
+
+		PointTransaction tx = mockTransaction(UUID.randomUUID(), Instant.now().minusSeconds(120), 1500L, PointTxType.SETTLEMENT_IN);
+		Slice<PointTransaction> slice = new SliceImpl<>(List.of(tx), PageRequest.of(0, 1), false);
+
+		when(walletRepository.findByUserId(userId)).thenReturn(Optional.of(wallet));
+		when(pointTransactionRepository.findNextPointTransactions(
+			eq(wallet.getWalletId()), eq(from), eq(to), eq(cursorTime), eq(cursorId), any()))
+			.thenReturn(slice);
+
+		GetPointTransactionPageResult result = queryService.getPointTransactions(
+			userId,
+			GetPointTransactionQuery.of(from, to, cursorTime, cursorId, 1)
+		);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0).amount()).isEqualTo(1500L);
+		assertThat(result.hasNext()).isFalse();
+		assertThat(result.nextCursorId()).isNull();
+		assertThat(result.nextCursorTime()).isNull();
+
+		verify(pointTransactionRepository, times(1))
+			.findNextPointTransactions(eq(wallet.getWalletId()), eq(from), eq(to), eq(cursorTime), eq(cursorId), any());
+		verify(pointTransactionRepository, never())
+			.findFirstPointTransactions(any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("지갑이 없으면 WalletException을 던진다")
+	void getPointTransactions_walletNotFound_throwsException() {
+		UUID userId = UUID.randomUUID();
+		when(walletRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> queryService.getPointTransactions(
+			userId,
+			GetPointTransactionQuery.of(null, null, null, null, 10)
+		)).isInstanceOf(WalletException.class);
+
+		verifyNoInteractions(pointTransactionRepository);
+	}
+
+	private PointTransaction mockTransaction(UUID id, Instant createdAt, long amount, PointTxType pointTxType) {
+		PointTransaction tx = mock(PointTransaction.class);
+		when(tx.getPointTransactionId()).thenReturn(id);
+		when(tx.getCreatedAt()).thenReturn(createdAt);
+		when(tx.getUsePoint()).thenReturn(amount);
+		when(tx.getPointTxType()).thenReturn(pointTxType);
+		return tx;
+	}
+}


### PR DESCRIPTION
- get transactions of point
- get balance in wallet

## 🌱 설명
잔액 조회 및 포인트 트랜젝션 기록 조회
- manyToOne으로 묶지 않고 cursor방식 이용하여 get
  - 이때 from ~ to 사이 시간으로 진행 (limit은 아직 설정해두지 않음)
  - manyToOne + fetch를 쓰나 직접 쿼리 조회하나 여러 wallet에 대해서 transaction을 한 번에 조회하지 않기 때문에 wallet 가져오면서 Tx 기록 fetch join하지 않음
  
- 바로 long으로 조회되도록 진행

## 📌 관련 이슈

close #20 

## ✅ 주요 변경 사항

-
-
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 포인트 거래 내역 조회 API 추가: 기간 필터와 커서 기반 페이지네이션(다음 커서 제공) 지원
  * 현재 지갑 잔액 조회 API 추가
* **Behavior Changes**
  * 거래 엔터티의 생성 시각 및 변경 금액 노출 방식 개선
  * 페이징 응답에 커서(다음 페이지 시간/ID) 포함 로직 추가
* **Tests**
  * 페이징 중복 방지 및 페이지 연결성 검증을 위한 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->