### PR TITLE
chore: GKE 배포 설정 추가 (wallet-service)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Build & Deploy wallet-service
+
+on:
+  push:
+    branches: [develop, dev]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/wallet-service
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/37902116541/locations/global/workloadIdentityPools/trusta-pool-github/providers/trusta-provider-github
+          service_account: trusta-sa-github-deployer@trusta-market-id.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg GPR_USER=${{ secrets.GPR_USER }} \
+            --build-arg GPR_TOKEN=${{ secrets.GPR_TOKEN }} \
+            -t $IMAGE:${{ github.sha }} -t $IMAGE:latest .
+
+      - name: Push image
+        run: docker push --all-tags $IMAGE
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: trusta-cluster
+          location: asia-northeast3-a
+
+      - name: Apply Deployment (with image tag substitution)
+        run: sed "s|PLACEHOLDER|${{ github.sha }}|g" k8s/deployment.yaml | kubectl apply -f -
+
+      - name: Apply Service
+        run: kubectl apply -f k8s/service.yaml
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/wallet-service --timeout=5m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.7
+
+FROM gradle:8.10-jdk21-alpine AS builder
+WORKDIR /workspace
+
+ARG GPR_USER
+ARG GPR_TOKEN
+
+COPY settings.gradle build.gradle ./
+COPY gradle ./gradle
+RUN GPR_USER="$GPR_USER" GPR_TOKEN="$GPR_TOKEN" gradle dependencies --no-daemon
+
+COPY src ./src
+
+RUN GPR_USER="$GPR_USER" GPR_TOKEN="$GPR_TOKEN" gradle bootJar --no-daemon \
+ && cp build/libs/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+RUN addgroup -g 1000 -S spring && adduser -u 1000 -S spring -G spring
+
+COPY --from=builder --chown=spring:spring /workspace/app.jar /app/app.jar
+
+USER spring:spring
+
+EXPOSE 8302
+
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
 }
 
 dependencies {
-	implementation 'com.trustamarket:common:0.0.1-SNAPSHOT'
+	implementation 'com.trustamarket:common:0.1.0-SNAPSHOT'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wallet-service
+  labels:
+    app: wallet-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wallet-service
+  template:
+    metadata:
+      labels:
+        app: wallet-service
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wallet-service
+          image: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/wallet-service:PLACEHOLDER
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8302
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: PROFILE
+              value: "k8s"
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_USERNAME
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_PASSWORD
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8302
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8302
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8302
+            periodSeconds: 5

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wallet-service
+  labels:
+    app: wallet-service
+spec:
+  type: ClusterIP
+  selector:
+    app: wallet-service
+  ports:
+    - port: 80
+      targetPort: 8302
+      protocol: TCP

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -1,0 +1,37 @@
+# K8s 환경 전용 override (SPRING_PROFILES_ACTIVE=k8s 일 때만 로드).
+
+server:
+  port: 8302
+
+spring:
+  config:
+    import: "optional:configserver:http://config-server"
+  cloud:
+    config:
+      uri: http://config-server
+      label: develop
+      fail-fast: false
+      # application.yaml 의 discovery.enabled:true 를 K8s 에선 비활성 (Service DNS 직접 사용)
+      discovery:
+        enabled: false
+  datasource:
+    url: jdbc:postgresql://postgres:5432/trusta_market
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        default_schema: p_wallet
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://eureka-server/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,3 +29,13 @@ eureka:
 trusta:
   security:
     trust-gateway-headers: true
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus


### PR DESCRIPTION
## 🌱 설명

wallet-service GKE 배포 셋업. 도메인 공유 PG + config-server + Eureka 연동.
schema `p_wallet` 사용.

## ✅ 주요 변경 사항

- `application.yaml` — management 블록 추가 (health probes + prometheus)
- `application-k8s.yml` (신규) — Spring Profile k8s: server.port 8302, config-server URI, datasource (placeholder), jpa(schema p_wallet), eureka. application.yaml 의 `config.cloud.discovery.enabled: true` 는 K8s 에서 false 로 override (Service DNS 직접 사용)
- `build.gradle` — `micrometer-registry-prometheus` 추가
- `Dockerfile` — multi-stage + non-root spring UID 1000, `ARG GPR_USER/GPR_TOKEN`
- `k8s/deployment.yaml` — replicas 1, env SPRING_PROFILES_ACTIVE=k8s + PROFILE=k8s + DB Secret, securityContext, probes
- `k8s/service.yaml` — ClusterIP port 80 → targetPort 8302
- `.github/workflows/deploy.yml` — develop / dev 모두 트리거 (default branch 가 아직 dev)

## 🔧 머지 전 필수

- Postgres 에 schema `p_wallet` 미리 생성:
  ```bash
  kubectl exec deployment/postgres -- psql -U trusta_admin -d trusta_market -c "CREATE SCHEMA IF NOT EXISTS p_wallet"
  ```
- Secret `domain-postgres-secrets` 이미 존재

## 🧪 검증

```bash
kubectl get pods -l app=wallet-service
kubectl logs deployment/wallet-service --tail=60
```

## 📚 후속

- default branch `dev` → `develop` 통일
- 환경 설정 config-repo 통합 (refactor issue 참조)
