### PR TITLE
fix: wallet-service K8s 환경 startup 실패 수정

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -53,9 +53,11 @@ spec:
             limits:
               cpu: 1000m
               memory: 2Gi
+          # startupProbe — /actuator/health/liveness (application 자체만).
+          # /actuator/health (전체 합산) 는 외부 의존성 (Kafka 등) DOWN 시 503 → kill.
           startupProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/liveness
               port: 8302
             failureThreshold: 30
             periodSeconds: 5

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -26,6 +26,14 @@ spring:
         default_schema: p_wallet
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
+  # Redis — K8s 환경 미사용. RedisAutoConfiguration 비활성 (캐싱 코드 있어도 startup OK).
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+  # Kafka — GKE namespace 'kafka' 의 StatefulSet 3 broker.
+  kafka:
+    bootstrap-servers: kafka.kafka:9092
 
 eureka:
   client:


### PR DESCRIPTION
  - Redis: K8s 미사용. RedisAutoConfiguration exclude
  - Kafka: bootstrap-servers kafka.kafka:9092 추가
  - startupProbe: /actuator/health → /actuator/health/liveness

## 🌱 설명

이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

-
-
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 쿠버네티스 환경에서 애플리케이션 헬스체크 메커니즘 최적화
* 메시지 큐 연결 설정 추가
* 레디스 자동 설정 비활성화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/wallet-service/pull/36)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->