### PR TITLE
fix: K8s 환경 Kafka listener manual ack-mode 추가

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -32,8 +32,19 @@ spring:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
       - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
   # Kafka — GKE namespace 'kafka' 의 StatefulSet 3 broker.
+  # listener.ack-mode: manual — PointSettlementListener 가 Acknowledgment 파라미터 받음.
   kafka:
     bootstrap-servers: kafka.kafka:9092
+    listener:
+      ack-mode: manual
+    consumer:
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 eureka:
   client:


### PR DESCRIPTION
  application-dev.yaml 에는 있던 listener/consumer 설정이 k8s 에 누락.
  PointSettlementListener 가 Acknowledgment 파라미터를 받는데 default  BATCH ack-mode 로 떨어져 IllegalStateException 발생
dev 프로필 설정과 동일하게 보강함

## 🌱 설명

이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

-
-
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.
