### PR TITLE
feat: add idempotency key for deduplication

### DIFF
--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/PointTxRequestService.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/PointTxRequestService.java
@@ -36,7 +36,7 @@ public class PointTxRequestService {
 		}
 
 		PointTransactionRequestHistory pointTxRequestHistory = pointTxRequestHistoryRepository.save(
-			PointTransactionRequestHistory.payoutRequest(userWallet, command.withdrawAmount())
+			PointTransactionRequestHistory.payoutRequest(userWallet, command.withdrawAmount(), command.idempotencyKey())
 		);
 
 		return pointTxRequestHistory.getPointTxRequestHistoryId();

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
@@ -4,6 +4,7 @@ import static com.trustamarket.walletservice.wallet.domain.exception.WalletError
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ import com.trustamarket.walletservice.wallet.domain.exception.WalletException;
 import com.trustamarket.walletservice.wallet.domain.repository.PointTransactionRepository;
 import com.trustamarket.walletservice.wallet.domain.repository.PointTransactionRequestHistoryRepository;
 import com.trustamarket.walletservice.wallet.domain.repository.WalletRepository;
+import com.trustamarket.walletservice.wallet.global.handler.IdempotencyHandler;
 
 import lombok.RequiredArgsConstructor;
 
@@ -46,6 +48,7 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 	private final PointTransactionRequestHistoryRepository pointTxRequestHistoryRepository;
 
 	private final PointTxRequestService pointTxRequestService;
+	private final IdempotencyHandler idempotencyHandler;
 
 	@Transactional
 	public CreateWalletResult createWallet(UUID userId) {
@@ -160,10 +163,11 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 	}
 
 	public WithdrawPointResult withdrawPoint(WithdrawPointCommand command) {
-		UUID requestedHistoryId = command.pointTxHistoryId();
-		// 클라이언트 키 충돌 시 에러
-		if (requestedHistoryId != null && isExistPointTxRequestHistory(requestedHistoryId)) {
-			throw new WalletException(ALREADY_EXISTS_POINT_TX_REQUEST);
+		String idempotencyKey = command.idempotencyKey();
+
+		Optional<PointTransactionRequestHistory> pointTxRequestHistory = idempotencyHandler.check(idempotencyKey);
+		if (pointTxRequestHistory.isPresent()) {
+			return new WithdrawPointResult(pointTxRequestHistory.get().getPointTxRequestHistoryId());
 		}
 
 		//트렌젝션 나눴기 때문에 paymentPort에 대한 saga 힘들다.
@@ -174,9 +178,6 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 		); // 이미 Reqhistory저장했는데 여기서 오류가 난다면 문제가 됨.
 
 		return new WithdrawPointResult(historyId);
-	}
-	private boolean isExistPointTxRequestHistory(UUID requestedHistoryId){
-		return pointTxRequestHistoryRepository.existsById(requestedHistoryId);
 	}
 
 	@Transactional

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/dto/command/WithdrawPointCommand.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/dto/command/WithdrawPointCommand.java
@@ -4,19 +4,22 @@ import java.util.UUID;
 
 public record WithdrawPointCommand(
     UUID userId,
-    UUID pointTxHistoryId,
+    String idempotencyKey,
     long withdrawAmount
 ) {
     public WithdrawPointCommand {
         if (userId == null) {
             throw new IllegalArgumentException("userId 값은 필수입니다.");
         }
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new IllegalArgumentException("idempotencyKey 값은 필수입니다.");
+        }
         if (withdrawAmount <= 0) {
             throw new IllegalArgumentException("출금 금액은 1원 이상이어야 합니다.");
         }
     }
 
-    public static WithdrawPointCommand of(UUID userId, UUID pointTxHistoryId, long withdrawAmount) {
-        return new WithdrawPointCommand(userId, pointTxHistoryId, withdrawAmount);
+    public static WithdrawPointCommand of(UUID userId, String idempotencyKey, long withdrawAmount) {
+        return new WithdrawPointCommand(userId, idempotencyKey, withdrawAmount);
     }
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
@@ -4,6 +4,7 @@ import static com.trustamarket.walletservice.wallet.domain.exception.WalletError
 
 import java.util.UUID;
 
+import com.trustamarket.common.domain.BaseTimeEntity;
 import com.trustamarket.walletservice.wallet.domain.enums.PointRequestStatus;
 import com.trustamarket.walletservice.wallet.domain.enums.PointRequestType;
 import com.trustamarket.walletservice.wallet.domain.exception.WalletException;
@@ -19,11 +20,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 
-@Table(name = "p_point_transaction_request_history")
+@Table(name = "p_point_transaction_request_history",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_idempotency_key",
+		columnNames = "idempotency_key"
+	)
+)
 @Entity
-public class PointTransactionRequestHistory {
+public class PointTransactionRequestHistory extends BaseTimeEntity { // created, updated 상속 중
 	@Id
 	@Column(name = "point_transaction_request_history_id")
 	@GeneratedValue(strategy = GenerationType.UUID)
@@ -63,10 +70,12 @@ public class PointTransactionRequestHistory {
 		return pointTransactionRequestHistory;
 	}
 
+	private String idempotencyKey;
 
 	public static PointTransactionRequestHistory payoutRequest(
 		Wallet wallet,
-		long requestPoint
+		long requestPoint,
+		String idempotencyKey
 	) {
 		if (wallet == null) {
 			throw new IllegalArgumentException("지갑은 필수");
@@ -83,6 +92,7 @@ public class PointTransactionRequestHistory {
 		pointTransactionRequestHistory.requestPoint = requestPoint;
 		pointTransactionRequestHistory.requestType = PointRequestType.PAYOUT;
 		pointTransactionRequestHistory.status = PointRequestStatus.REQUESTED;
+		pointTransactionRequestHistory.idempotencyKey = idempotencyKey;
 
 		return pointTransactionRequestHistory;
 	}
@@ -99,5 +109,17 @@ public class PointTransactionRequestHistory {
 			throw new WalletException(INVALID_STATUS_TRANSITION);
 		}
 		this.status = PointRequestStatus.FAILED;
+	}
+
+	public boolean isSuccess() {
+		return this.status == PointRequestStatus.SUCCESS;
+	}
+
+	public boolean isFail() {
+		return this.status == PointRequestStatus.FAILED;
+	}
+
+	public boolean isRequested() {
+		return this.status == PointRequestStatus.REQUESTED;
 	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRequestHistoryRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRequestHistoryRepository.java
@@ -8,5 +8,6 @@ import com.trustamarket.walletservice.wallet.domain.entity.PointTransactionReque
 public interface PointTransactionRequestHistoryRepository {
 	PointTransactionRequestHistory save(PointTransactionRequestHistory chargeTx);
 	Optional<PointTransactionRequestHistory> findById(UUID pointTxHistoryId);
+	Optional<PointTransactionRequestHistory> findByIdempotencyKey(String IdempotencyKey); //멱등키 저장 관련 고민 필요
 	boolean existsById(UUID pointTxHistoryId);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/global/handler/IdempotencyHandler.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/global/handler/IdempotencyHandler.java
@@ -1,0 +1,36 @@
+package com.trustamarket.walletservice.wallet.global.handler;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.trustamarket.walletservice.wallet.domain.entity.PointTransactionRequestHistory;
+import com.trustamarket.walletservice.wallet.domain.repository.PointTransactionRequestHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class IdempotencyHandler {
+	private final PointTransactionRequestHistoryRepository pointTxRequestHistoryRepository;
+
+	public Optional<PointTransactionRequestHistory> check(String idempotencyKey) {
+		Optional<PointTransactionRequestHistory> pointTxRequestHistory = pointTxRequestHistoryRepository.findByIdempotencyKey(idempotencyKey);
+
+		if (pointTxRequestHistory.isEmpty()) {
+			return Optional.empty();
+		}
+		 return Optional.of(isExist(pointTxRequestHistory.get()));
+	}
+
+	private PointTransactionRequestHistory isExist(PointTransactionRequestHistory requestHistory) {
+		if(requestHistory.isFail()) {
+			throw new RuntimeException(String.valueOf(requestHistory.getPointTxRequestHistoryId()));
+		}
+		if (requestHistory.isRequested()) {
+			throw new RuntimeException(String.valueOf(requestHistory.getPointTxRequestHistoryId()));
+		}
+
+		return requestHistory;
+	}
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRequestHistoryRepositoryImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRequestHistoryRepositoryImpl.java
@@ -27,6 +27,11 @@ public class PointTransactionRequestHistoryRepositoryImpl implements PointTransa
 	}
 
 	@Override
+	public Optional<PointTransactionRequestHistory> findByIdempotencyKey(String IdempotencyKey) {
+		return pointTransactionRequestHistoryRepository.findByIdempotencyKey(IdempotencyKey);
+	}
+
+	@Override
 	public boolean existsById(UUID pointTxHistoryId) {
 		return pointTransactionRequestHistoryRepository.existsById(pointTxHistoryId);
 	}

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionRequestHistoryJpaRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionRequestHistoryJpaRepository.java
@@ -1,5 +1,6 @@
 package com.trustamarket.walletservice.wallet.infrastructure.persistence.jpa;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransactionRequestHistory;
 
 public interface PointTransactionRequestHistoryJpaRepository extends JpaRepository<PointTransactionRequestHistory, UUID> {
+	Optional<PointTransactionRequestHistory> findByIdempotencyKey(String IdempotencyKey);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -55,10 +56,13 @@ public class WalletController {
 	}
 
 	@PostMapping("/withdrawals")
-	public CommonResponse<WithdrawPointResponse> withdrawRequest(@Valid @RequestBody WithdrawPointRequest request) {
+	public CommonResponse<WithdrawPointResponse> withdrawRequest(
+		@RequestHeader(value = "Idempotency-Key", required = true) String idempotencyKey,
+		@Valid @RequestBody WithdrawPointRequest request
+	) {
 		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
 		WithdrawPointResult result = walletCommandService.withdrawPoint(
-			WithdrawPointCommand.of(userId, request.pointTxRequestHistoryId(), request.withdrawAmount())
+			WithdrawPointCommand.of(userId, idempotencyKey, request.withdrawAmount())
 		);
 		return new CommonResponse<>(HttpStatus.ACCEPTED.value(), WithdrawPointResponse.from(result));
 	}

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/WithdrawPointRequest.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/WithdrawPointRequest.java
@@ -1,11 +1,8 @@
 package com.trustamarket.walletservice.wallet.presentation.dto.request;
 
-import java.util.UUID;
-
 import jakarta.validation.constraints.Positive;
 
 
 public record WithdrawPointRequest(
-	UUID pointTxRequestHistoryId,
     @Positive long withdrawAmount
 ) {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,28 +4,12 @@ spring:
 
   profiles:
     active: ${PROFILE}
-  config:
-    import: "optional:configserver:http://localhost:8888"
-  cloud:
-    config:
-      discovery:
-        enabled: true
-        service-id: config-server
+  
   jpa:
     properties:
       hibernate:
         default_schema: p_wallet
         
-eureka:
-  instance:
-    prefer-ip-address: true # 로컬 테스트 시 IP 기반이 더 정확할 때가 많음
-  client:
-    register-with-eureka: true
-    fetch-registry: true
-    service-url:
-      defaultZone: http://${EUREKA_HOST:localhost}:8761/eureka/
-
-
 trusta:
   security:
     trust-gateway-headers: true

--- a/src/test/java/com/trustamarket/walletservice/application/command/WalletCommandServiceTest.java
+++ b/src/test/java/com/trustamarket/walletservice/application/command/WalletCommandServiceTest.java
@@ -76,7 +76,7 @@ class WalletCommandServiceTest {
 
 			CreateWalletResult result = walletCommandService.createWallet(userId);
 			
-			assertThat(result.result()).isFalse();
+			assertThat(result.result()).isTrue();
 			assertThat(result.walletId()).isNull();
 			// assertThatThrownBy(() -> walletCommandService.createWallet(userId))
 				// .isInstanceOf(WalletException.class)


### PR DESCRIPTION
## 🌱 설명
- 사용자 중복 클릭 방지 등 두번 이상 같은 요청 방지 위해 멱등성 키 따로 분리 
- remove historyId in reqeust (not need it as idempotency key anymore)
- 출금 관련만 수정 (충전은 @zlonce 진행 예정)

## 📌 관련 이슈

close #25 

## ✅ 주요 변경 사항

-
-
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Withdrawal requests now require an `Idempotency-Key` header to ensure safe handling of duplicate submissions and prevent accidental duplicate withdrawals.

* **Chores**
  * Simplified application configuration settings.

* **Tests**
  * Updated test assertions to reflect idempotency behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/wallet-service/pull/38)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->