### PR TITLE
chore(deps): bump common 0.2.0-SNAPSHOT -> 0.3.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
 }
 
 dependencies {
-	implementation 'com.trustamarket:common:0.2.0-SNAPSHOT'
+	implementation 'com.trustamarket:common:0.3.0-SNAPSHOT'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'


### PR DESCRIPTION
## 🌱 설명

common 라이브러리 `0.2.0-SNAPSHOT` → `0.3.0-SNAPSHOT` bump.

trusta-market/common#6 머지로 `/actuator/prometheus` 의 `byte[]` 응답이 `CommonResponse` 로 wrap 되어 500 나는 문제 fix. 이 service 도 bump 해야 GMP 가 메트릭 scrape 가능.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- `build.gradle` 의 `com.trustamarket:common` dependency: `0.2.0-SNAPSHOT` → `0.3.0-SNAPSHOT`

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

머지 + 재배포 후 `kubectl port-forward <service> 8888:<container-port>` + `curl http://localhost:8888/actuator/prometheus` 응답이 200 + Prometheus exposition format 인지 확인.
