### PR TITLE
fix(wallet): GetPointTransactionsRequest from/to validation 조건 반대 수정

### DIFF
--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/GetPointTransactionsRequest.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/GetPointTransactionsRequest.java
@@ -22,7 +22,7 @@ public record GetPointTransactionsRequest(
 		to = getValidTo();
 		from = getValidFrom();
 
-		if (!from.isAfter(to)) {
+		if (from.isAfter(to)) {
 			throw new IllegalArgumentException("to가 더 최근이여야 함");
 		}
 		if(!isValidCursor()) {


### PR DESCRIPTION
## 🌱 설명

`GET /api/v1/wallets/transactions` 호출 시 500 `IllegalArgumentException: to가 더 최근이여야 함` 발생.

원인: validation 조건 `!from.isAfter(to)` 가 정상 케이스 (from < to) 일 때 throw 라 모든 호출 fail.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- `GetPointTransactionsRequest` 의 validation: `!from.isAfter(to)` → `from.isAfter(to)` (한 글자, `!` 제거)
- 결과: `from > to` (역순) 일 때만 throw — 의도와 일치

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

smoke test 중 발견. 부하 테스트 시나리오엔 `/transactions` 호출 없지만 외부 client 가 호출 시 fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포인트 거래 조회 시 날짜 범위 검증 로직이 올바르게 동작하도록 수정되었습니다. 이제 조회 기간의 시작일과 종료일이 올바른 순서로 입력되었는지 정확히 확인합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/wallet-service/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->