### PR TITLE
fix: add ResponseEntity in controller response

### DIFF
--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/payment/PaymentAdapter.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/payment/PaymentAdapter.java
@@ -2,13 +2,12 @@ package com.trustamarket.walletservice.wallet.infrastructure.payment;
 
 import java.util.UUID;
 
-import com.trustamarket.walletservice.wallet.application.dto.result.ChargePointResult;
-import com.trustamarket.walletservice.wallet.application.dto.result.CreateWalletResult;
-import com.trustamarket.walletservice.wallet.infrastructure.payment.dto.PaymentPointResponse;
 import org.springframework.stereotype.Component;
 
+import com.trustamarket.walletservice.wallet.application.dto.result.ChargePointResult;
 import com.trustamarket.walletservice.wallet.application.port.PaymentPort;
 import com.trustamarket.walletservice.wallet.infrastructure.payment.dto.PaymentPointRequest;
+import com.trustamarket.walletservice.wallet.infrastructure.payment.dto.PaymentPointResponse;
 import com.trustamarket.walletservice.wallet.infrastructure.payment.dto.WithdrawRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -22,7 +21,7 @@ public class PaymentAdapter implements PaymentPort {
     @Override
     public ChargePointResult chargePoint(UUID userId, UUID pointTxRequestHistoryId, long chargeAmount) {
         PaymentPointRequest request = new PaymentPointRequest(userId, pointTxRequestHistoryId, chargeAmount);
-        PaymentPointResponse response = paymentFeignClient.paymentPoint(request).data();
+        PaymentPointResponse response = paymentFeignClient.paymentPoint(request).getBody().data(); //ResponseEntity -> CommonResponse의 body
         ChargePointResult result = new ChargePointResult(
                 response.paymentId(),
                 response.pointTxRequestHistoryId(),

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/payment/PaymentFeignClient.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/payment/PaymentFeignClient.java
@@ -1,24 +1,25 @@
 package com.trustamarket.walletservice.wallet.infrastructure.payment;
 
-import com.trustamarket.walletservice.wallet.infrastructure.payment.dto.PaymentPointResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.walletservice.wallet.infrastructure.payment.dto.PaymentPointRequest;
+import com.trustamarket.walletservice.wallet.infrastructure.payment.dto.PaymentPointResponse;
 import com.trustamarket.walletservice.wallet.infrastructure.payment.dto.WithdrawRequest;
 
 @FeignClient(name = "payment-service", path = "/internal/v1")
 public interface PaymentFeignClient {
 
     @PostMapping("/payments/charges")
-    CommonResponse<PaymentPointResponse> paymentPoint(
+    ResponseEntity<CommonResponse<PaymentPointResponse>> paymentPoint(
             @RequestBody PaymentPointRequest request
     );
 
     @PostMapping("/payouts")
-    CommonResponse<Void> withdraw(
+    ResponseEntity<Void> withdraw(
         @RequestBody WithdrawRequest request
     );
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletController.java
@@ -3,6 +3,7 @@ package com.trustamarket.walletservice.wallet.presentation;
 import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -45,7 +46,7 @@ public class WalletController {
 	private final WalletQueryService walletQueryService;
 
 	@PostMapping("/charges")
-	public CommonResponse<ChargePointResponse> chargePoint(
+	public ResponseEntity<CommonResponse<ChargePointResponse>> chargePoint(
 			@RequestHeader(value = "Idempotency-Key", required = true) String idempotencyKey,
 			@Valid @RequestBody ChargePointRequest request
 	){
@@ -55,21 +56,23 @@ public class WalletController {
 		ChargePointResult result = walletCommandService.chargePoint(command);
 		ChargePointResponse response = ChargePointResponse.from(result);
 
-		return new CommonResponse<>(HttpStatus.ACCEPTED.value(), response);
+		return ResponseEntity.status(HttpStatus.ACCEPTED)
+			.body(CommonResponse.of(HttpStatus.ACCEPTED.value(), response));
 	}
 
 	@PostMapping("/withdrawals")
-	public CommonResponse<WithdrawPointResponse> withdrawRequest(
+	public ResponseEntity<CommonResponse<WithdrawPointResponse>> withdrawRequest(
 			@RequestHeader(value = "Idempotency-Key", required = true) String idempotencyKey,
 			@Valid @RequestBody WithdrawPointRequest request) {
 		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
 		WithdrawPointResult result = walletCommandService.withdrawPoint(
 				WithdrawPointCommand.of(userId, idempotencyKey, request.withdrawAmount()));
-		return new CommonResponse<>(HttpStatus.ACCEPTED.value(), WithdrawPointResponse.from(result));
+		return ResponseEntity.status(HttpStatus.ACCEPTED)
+			.body(CommonResponse.of(HttpStatus.ACCEPTED.value(), WithdrawPointResponse.from(result)));
 	}
 
 	@GetMapping("/transactions")
-	public CommonResponse<GetPointTransactionPageResult> getPointTransactions(
+	public ResponseEntity<CommonResponse<GetPointTransactionPageResult>> getPointTransactions(
 			@Valid @ModelAttribute GetPointTransactionsRequest queryRequest) {
 		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
 		GetPointTransactionPageResult result = walletQueryService.getPointTransactions(
@@ -78,23 +81,24 @@ public class WalletController {
 						queryRequest.getValidFrom(), queryRequest.getValidTo(),
 						queryRequest.cursorTime(), queryRequest.cursorId(),
 						queryRequest.size()));
-		return new CommonResponse<>(HttpStatus.OK.value(), result);
+		return ResponseEntity.ok(CommonResponse.of(HttpStatus.OK.value(), result));
 	}
 
 	@GetMapping("/balances")
-	public CommonResponse<Long> getPointBalance() {
+	public ResponseEntity<CommonResponse<Long>> getPointBalance() {
 		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
 		long balance = walletQueryService.getPoint(userId);
-		return new CommonResponse<>(HttpStatus.OK.value(), balance);
+		return ResponseEntity.ok(CommonResponse.of(HttpStatus.OK.value(), balance));
 	}
 
 	@PreAuthorize("hasRole('ADMIN')")
 	@PostMapping("/system")
-	public CommonResponse<CreateSystemWalletResponse> createSystemWallet(
+	public ResponseEntity<CommonResponse<CreateSystemWalletResponse>> createSystemWallet(
 			@Valid @RequestBody CreateSystemWalletRequest request) {
 		Wallet result = systemWalletService.createSystemWallet(
 				CreateSystemWalletDto.of(request.operatorId(), request.walletType()));
 
-		return new CommonResponse<>(HttpStatus.CREATED.value(), CreateSystemWalletResponse.from(result));
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(CommonResponse.of(HttpStatus.CREATED.value(), CreateSystemWalletResponse.from(result)));
 	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
@@ -47,7 +47,7 @@ public class WalletInternalController {
 	}
 
 	@PostMapping("/charges")
-	public ResponseEntity<CommonResponse<Void>> chargeComplete(@Valid @RequestBody ChargeCompleteRequest request){
+	public ResponseEntity<Void> chargeComplete(@Valid @RequestBody ChargeCompleteRequest request){
 		walletCommandService.chargeComplete(new ChargeCompleteCommand(
 				request.userId(),
 				request.paymentId(),
@@ -56,12 +56,11 @@ public class WalletInternalController {
 				request.chargeAmount()
 		));
 
-		return ResponseEntity.status(HttpStatus.NO_CONTENT)
-			.body(CommonResponse.of(HttpStatus.NO_CONTENT.value(), null));
+		return ResponseEntity.noContent().build();
 	}
 
 	@PostMapping("/withdrawals")
-	public ResponseEntity<CommonResponse<Void>> withdrawComplete(@Valid @RequestBody WithdrawCompleteRequest request) {
+	public ResponseEntity<Void> withdrawComplete(@Valid @RequestBody WithdrawCompleteRequest request) {
 		walletCommandService.withdrawComplete(WithdrawCompleteCommand.of(
 			request.userId(),
 			request.payoutId(),
@@ -69,7 +68,6 @@ public class WalletInternalController {
 			PointRequestStatus.from(request.payoutStatus()),
 			request.payoutAmount()
 		));
-		return ResponseEntity.status(HttpStatus.NO_CONTENT)
-			.body(CommonResponse.of(HttpStatus.NO_CONTENT.value(), null));
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
@@ -1,11 +1,11 @@
 package com.trustamarket.walletservice.wallet.presentation;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.trustamarket.common.response.CommonResponse;
@@ -32,22 +32,22 @@ import lombok.RequiredArgsConstructor;
 public class WalletInternalController {
 	private final WalletCommandService walletCommandService;
 
-	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
-	public CreateWalletResponse createWallet(@RequestBody CreateWalletRequest request) {
+	public ResponseEntity<CommonResponse<CreateWalletResponse>> createWallet(@RequestBody CreateWalletRequest request) {
 		CreateWalletResult createResult = walletCommandService.createWallet(request.userId());
-		return new CreateWalletResponse(createResult.result());
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(CommonResponse.of(HttpStatus.CREATED.value(), new CreateWalletResponse(createResult.result())));
 	}
 
 	@PatchMapping("/usages")
-	public CommonResponse<UseWalletResponse> usePoint (@Valid @RequestBody UseWalletRequest request) {
+	public ResponseEntity<CommonResponse<UseWalletResponse>> usePoint (@Valid @RequestBody UseWalletRequest request) {
 		UseWalletResult result = walletCommandService.usePoint(new UseWalletCommand(request.orderId(), request.buyerId(), request.totalAmount()));
 		
-		return new CommonResponse(HttpStatus.OK.value(), new UseWalletResponse(result.balance(), result.shortage()));
+		return ResponseEntity.ok(CommonResponse.of(HttpStatus.OK.value(), new UseWalletResponse(result.balance(), result.shortage())));
 	}
 
 	@PostMapping("/charges")
-	public CommonResponse<Void> chargeComplete(@Valid @RequestBody ChargeCompleteRequest request){
+	public ResponseEntity<CommonResponse<Void>> chargeComplete(@Valid @RequestBody ChargeCompleteRequest request){
 		walletCommandService.chargeComplete(new ChargeCompleteCommand(
 				request.userId(),
 				request.paymentId(),
@@ -56,11 +56,12 @@ public class WalletInternalController {
 				request.chargeAmount()
 		));
 
-		return new CommonResponse(HttpStatus.NO_CONTENT.value(), null);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT)
+			.body(CommonResponse.of(HttpStatus.NO_CONTENT.value(), null));
 	}
 
 	@PostMapping("/withdrawals")
-	public CommonResponse<Void> withdrawComplete(@Valid @RequestBody WithdrawCompleteRequest request) {
+	public ResponseEntity<CommonResponse<Void>> withdrawComplete(@Valid @RequestBody WithdrawCompleteRequest request) {
 		walletCommandService.withdrawComplete(WithdrawCompleteCommand.of(
 			request.userId(),
 			request.payoutId(),
@@ -68,6 +69,7 @@ public class WalletInternalController {
 			PointRequestStatus.from(request.payoutStatus()),
 			request.payoutAmount()
 		));
-		return new CommonResponse<>(HttpStatus.NO_CONTENT.value(), null);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT)
+			.body(CommonResponse.of(HttpStatus.NO_CONTENT.value(), null));
 	}
 }


### PR DESCRIPTION
## 🌱 설명

controller에 responseEntity 및 CommonResponse 추가

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

-
-
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * API 응답이 명시적 HTTP 상태 코드로 표준화되고 응답 포맷이 일관되게 래핑되었습니다: 포인트 충전·출금 요청은 202 Accepted, 거래·잔액 조회는 200 OK, 시스템 지갑 생성(관리자)은 201 Created로 응답합니다.
  * 내부 생성/처리 엔드포인트는 응답 본문을 명확히 반환하거나(201/200) 완료 처리 시 본문 없이 204 No Content로 반환하도록 정리되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/wallet-service/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->