### PR TITLE
feat: add wallet usage lookup API for order recovery

### DIFF
--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
@@ -75,6 +75,12 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 		Wallet buyerWallet = walletRepository.findByUserId(command.buyerId())
 			.orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
 
+		PointTransactionRequestHistory attempt =
+			PointTransactionRequestHistory.orderPaymentAttempt(
+				buyerWallet, command.totalAmount(), command.orderId()
+			);
+		pointTxRequestHistoryRepository.save(attempt);
+
 		long currentBalance = buyerWallet.checkBalance();
 		if (currentBalance < command.totalAmount()) {
 			long shortage = command.totalAmount() - currentBalance;

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
@@ -21,10 +21,12 @@ import com.trustamarket.walletservice.wallet.application.dto.result.CreateWallet
 import com.trustamarket.walletservice.wallet.application.dto.result.UseWalletResult;
 import com.trustamarket.walletservice.wallet.application.dto.result.WithdrawPointResult;
 import com.trustamarket.walletservice.wallet.application.port.PaymentPort;
+import com.trustamarket.walletservice.wallet.domain.entity.PointShortage;
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransactionRequestHistory;
 import com.trustamarket.walletservice.wallet.domain.entity.Wallet;
 import com.trustamarket.walletservice.wallet.domain.enums.PointRequestStatus;
+import com.trustamarket.walletservice.wallet.domain.enums.PointRequestType;
 import com.trustamarket.walletservice.wallet.domain.enums.PointTxType;
 import com.trustamarket.walletservice.wallet.domain.enums.RefType;
 import com.trustamarket.walletservice.wallet.domain.exception.WalletErrorCode;
@@ -75,9 +77,31 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 		Wallet buyerWallet = walletRepository.findByUserId(command.buyerId())
 			.orElseThrow(() -> new WalletException(WalletErrorCode.WALLET_NOT_FOUND));
 
+		// 같은 idempotency key있을 때 처리 상태에 따라 return
+		String idempotencyKey = command.idempotencyKey().toString();
+		Optional<PointTransactionRequestHistory> existing =
+			pointTxRequestHistoryRepository.findByIdempotencyKeyAndRefIdAndPointRequestType(
+				idempotencyKey, command.orderId(), PointRequestType.ORDER_PAYMENT
+			);
+		if (existing.isPresent()) {
+			PointTransactionRequestHistory history = existing.get();
+			if (history.isSuccess()) {
+				return UseWalletResult.success(buyerWallet.checkBalance());
+			}
+			PointShortage pointShortage = history.getPointShortage();
+			return UseWalletResult.insufficient(pointShortage.getBalance(), pointShortage.getShortage());
+		}
+
+		//다른 결제 요청이지만 이미 포인트 사용 내역이 있다면 종료
+		if (pointTransactionRepository.existsByRefIdAndPointTxType(
+			command.orderId(), PointTxType.BUYER_PAYMENT)) {
+			return UseWalletResult.success(buyerWallet.checkBalance());
+		}
+
+
 		PointTransactionRequestHistory attempt =
 			PointTransactionRequestHistory.orderPaymentAttempt(
-				buyerWallet, command.totalAmount(), command.orderId()
+				buyerWallet, command.totalAmount(), command.orderId(), idempotencyKey
 			);
 
 		long currentBalance = buyerWallet.checkBalance();

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
@@ -88,8 +88,10 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 			if (history.isSuccess()) {
 				return UseWalletResult.success(buyerWallet.checkBalance());
 			}
-			PointShortage pointShortage = history.getPointShortage();
-			return UseWalletResult.insufficient(pointShortage.getBalance(), pointShortage.getShortage());
+			if (history.isInsufficient()) {
+				PointShortage pointShortage = history.getPointShortage();
+				return UseWalletResult.insufficient(pointShortage.getBalance(), pointShortage.getShortage());
+			}
 		}
 
 		//다른 결제 요청이지만 이미 포인트 사용 내역이 있다면 종료

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/command/WalletCommandServiceImpl.java
@@ -79,11 +79,12 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 			PointTransactionRequestHistory.orderPaymentAttempt(
 				buyerWallet, command.totalAmount(), command.orderId()
 			);
-		pointTxRequestHistoryRepository.save(attempt);
 
 		long currentBalance = buyerWallet.checkBalance();
 		if (currentBalance < command.totalAmount()) {
 			long shortage = command.totalAmount() - currentBalance;
+			attempt.insufficient();
+			pointTxRequestHistoryRepository.save(attempt);
 			return UseWalletResult.insufficient(currentBalance, shortage);
 		}
 
@@ -96,6 +97,8 @@ public class WalletCommandServiceImpl implements WalletCommandService {
 			command.totalAmount(), command.orderId(), RefType.ORDER, PointTxType.ESCROW_DEPOSIT
 		);
 
+		attempt.success();
+		pointTxRequestHistoryRepository.save(attempt);
 		walletRepository.save(buyerWallet);
 		walletRepository.save(systemEscrow);
 		pointTransactionRepository.saveAll(List.of(userTx, escrowTx));

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/dto/command/UseWalletCommand.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/dto/command/UseWalletCommand.java
@@ -3,11 +3,15 @@ package com.trustamarket.walletservice.wallet.application.dto.command;
 import java.util.UUID;
 
 public record UseWalletCommand(
+	UUID idempotencyKey,
 	UUID orderId,
 	UUID buyerId,
 	Long totalAmount
 ) {
 	public UseWalletCommand {
+		if (idempotencyKey == null) {
+			throw new IllegalArgumentException("idempotencyKey는 필수입니다.");
+		}
 		if (orderId == null) {
 			throw new IllegalArgumentException("주문 ID는 필수입니다.");
 		}

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/dto/result/GetPointUsageResult.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/dto/result/GetPointUsageResult.java
@@ -1,0 +1,34 @@
+package com.trustamarket.walletservice.wallet.application.dto.result;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/*
+"orderId":    UUID,
+      "result":     "DEDUCTED" | "INSUFFICIENT" | "NOT_FOUND",
+      "amount":     long (nullable),       // DEDUCTED 만 채움
+      "balance":    long (nullable),       // 현재 잔액
+      "shortage":   long (nullable),       // INSUFFICIENT 시 부족 금액(0아니면 null로)
+      "deductedAt": Instant (nullable)     // DEDUCTED 만 채움
+ */
+public record GetPointUsageResult(
+	UUID orderId, WalletUsageStatus walletUsageStatus,
+	Long amount, Long balance, Long shortage,
+	Instant deductedAt
+) {
+	public enum WalletUsageStatus {
+		DEDUCTED, INSUFFICIENT, NOT_FOUND
+	}
+
+	public static GetPointUsageResult deduct(UUID orderId, long amount, Instant deductedAt) {
+		return new GetPointUsageResult(orderId, WalletUsageStatus.DEDUCTED, amount, null, null, deductedAt);
+	}
+
+	public static GetPointUsageResult insufficient(UUID orderId, long balance, long shortage) {
+		return new GetPointUsageResult(orderId, WalletUsageStatus.INSUFFICIENT, null, balance, shortage, null);
+	}
+
+	public static GetPointUsageResult notFound(UUID orderId) {
+		return new GetPointUsageResult(orderId, WalletUsageStatus.NOT_FOUND, null, null, null, null);
+	}
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryService.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryService.java
@@ -1,11 +1,13 @@
 package com.trustamarket.walletservice.wallet.application.query;
 
+import java.util.UUID;
+
 import com.trustamarket.walletservice.wallet.application.dto.query.GetPointTransactionQuery;
 import com.trustamarket.walletservice.wallet.application.dto.result.GetPointTransactionPageResult;
-
-import java.util.UUID;
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointUsageResult;
 
 public interface WalletQueryService {
 	long getPoint(UUID userId);
 	GetPointTransactionPageResult getPointTransactions(UUID userId, GetPointTransactionQuery query);
+	GetPointUsageResult getPointUsageTx(UUID orderId);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryServiceImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/application/query/WalletQueryServiceImpl.java
@@ -1,8 +1,10 @@
 package com.trustamarket.walletservice.wallet.application.query;
 
+import static com.trustamarket.walletservice.wallet.domain.enums.PointTxType.*;
 import static com.trustamarket.walletservice.wallet.domain.exception.WalletErrorCode.*;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
@@ -12,9 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.trustamarket.walletservice.wallet.application.dto.query.GetPointTransactionQuery;
 import com.trustamarket.walletservice.wallet.application.dto.result.GetPointTransactionPageResult;
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointUsageResult;
+import com.trustamarket.walletservice.wallet.domain.entity.PointShortage;
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransaction;
 import com.trustamarket.walletservice.wallet.domain.entity.Wallet;
 import com.trustamarket.walletservice.wallet.domain.exception.WalletException;
+import com.trustamarket.walletservice.wallet.domain.repository.PointShortageRepository;
 import com.trustamarket.walletservice.wallet.domain.repository.PointTransactionRepository;
 import com.trustamarket.walletservice.wallet.domain.repository.WalletRepository;
 
@@ -25,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class WalletQueryServiceImpl implements WalletQueryService{
 	private final WalletRepository walletRepository;
 	private final PointTransactionRepository pointTransactionRepository;
+	private final PointShortageRepository pointShortageRepository;
 
 	private static final int DEFAULT_PAGE_SIZE = 20;
 
@@ -34,6 +40,32 @@ public class WalletQueryServiceImpl implements WalletQueryService{
 			() -> new WalletException(WALLET_NOT_FOUND)
 		); // 추후 findAllByUserId 고려
 		return wallet.checkBalance();
+	}
+
+	@Transactional(readOnly = true)
+	public GetPointUsageResult getPointUsageTx(UUID orderId) {
+		Optional<PointTransaction> pointTransaction =
+			pointTransactionRepository.findByRefIdAndPointTxType(orderId, BUYER_PAYMENT);
+		if (pointTransaction.isPresent()) {
+			PointTransaction tx = pointTransaction.get();
+			return GetPointUsageResult.deduct(
+				orderId,
+				Math.abs(tx.getChangeAmount()),
+				tx.getCreatedAt()
+			);
+		}
+
+		Optional<PointShortage> shortage = pointShortageRepository.findByOrderId(orderId);
+		if (shortage.isPresent()) {
+			PointShortage s = shortage.get();
+			return GetPointUsageResult.insufficient(
+				orderId,
+				s.getBalance(),
+				s.getShortage()
+			);
+		}
+
+		return GetPointUsageResult.notFound(orderId);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointShortage.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointShortage.java
@@ -1,0 +1,40 @@
+package com.trustamarket.walletservice.wallet.domain.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Table(name = "p_point_shortage")
+public class PointShortage {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Getter
+	private UUID id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "point_transaction_request_history_id", nullable = false, unique = true)
+	private PointTransactionRequestHistory requestHistory;
+
+	@Getter
+	private long shortage;
+
+	@Getter
+	private long balance; // 부족했을 당시 잔액
+
+	public static PointShortage of(PointTransactionRequestHistory requestHistory, long shortage, long balance) {
+		PointShortage pointShortage = new PointShortage();
+		pointShortage.requestHistory = requestHistory;
+		pointShortage.shortage = shortage;
+		pointShortage.balance = balance;
+		return pointShortage;
+	}
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
@@ -169,4 +169,8 @@ public class PointTransactionRequestHistory extends BaseTimeEntity { // created,
 	public boolean isRequested() {
 		return this.status == PointRequestStatus.REQUESTED;
 	}
+
+	public boolean isInsufficient() {
+		return this.status == PointRequestStatus.INSUFFICIENT;
+	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
@@ -27,8 +27,7 @@ import lombok.Getter;
 
 @Table(name = "p_point_transaction_request_history",
 	uniqueConstraints = {
-		@UniqueConstraint(name = "uk_idempotency_key", columnNames = "idempotency_key"),
-		@UniqueConstraint(name = "uk_ref_id_request_type", columnNames = {"ref_id", "request_type"})
+		@UniqueConstraint(name = "uk_idempotency_key_ref_id_request_type", columnNames = {"idempotency_key", "ref_id","request_type"} ),
 	}
 )
 @Entity
@@ -110,7 +109,8 @@ public class PointTransactionRequestHistory extends BaseTimeEntity { // created,
 	public static PointTransactionRequestHistory orderPaymentAttempt(
 		Wallet wallet,
 		long requestPoint,
-		UUID refId
+		UUID refId,
+		String idempotencyKey
 	) {
 		if (wallet == null) {
 			throw new IllegalArgumentException("지갑은 필수");
@@ -125,6 +125,7 @@ public class PointTransactionRequestHistory extends BaseTimeEntity { // created,
 		pointTransactionRequestHistory.refId = refId;
 		pointTransactionRequestHistory.requestType = PointRequestType.ORDER_PAYMENT;
 		pointTransactionRequestHistory.status = PointRequestStatus.REQUESTED;
+		pointTransactionRequestHistory.idempotencyKey = idempotencyKey;
 
 		return pointTransactionRequestHistory;
 	}

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
@@ -9,6 +9,7 @@ import com.trustamarket.walletservice.wallet.domain.enums.PointRequestStatus;
 import com.trustamarket.walletservice.wallet.domain.enums.PointRequestType;
 import com.trustamarket.walletservice.wallet.domain.exception.WalletException;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,6 +20,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
@@ -49,6 +51,12 @@ public class PointTransactionRequestHistory extends BaseTimeEntity { // created,
 
 	@Getter
 	private long requestPoint;
+
+	private UUID refId;
+
+	@OneToOne(mappedBy = "requestHistory", cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
+	@Getter
+	private PointShortage pointShortage;
 
 	public static PointTransactionRequestHistory paymentRequest(
 			Wallet wallet,
@@ -98,6 +106,43 @@ public class PointTransactionRequestHistory extends BaseTimeEntity { // created,
 
 		return pointTransactionRequestHistory;
 	}
+
+	public static PointTransactionRequestHistory orderPaymentAttempt(
+		Wallet wallet,
+		long requestPoint,
+		UUID refId
+	) {
+		if (wallet == null) {
+			throw new IllegalArgumentException("지갑은 필수");
+		}
+		if (requestPoint <= 0) {
+			throw new IllegalArgumentException("주문 금액은 1원 이상이어야 합니다.");
+		}
+
+
+		PointTransactionRequestHistory pointTransactionRequestHistory = new PointTransactionRequestHistory();
+		pointTransactionRequestHistory.wallet = wallet;
+		pointTransactionRequestHistory.requestPoint = requestPoint;
+		pointTransactionRequestHistory.refId = refId;
+		pointTransactionRequestHistory.requestType = PointRequestType.ORDER_PAYMENT;
+		pointTransactionRequestHistory.status = PointRequestStatus.REQUESTED;
+
+		if (wallet.checkBalance() < requestPoint) {
+			pointTransactionRequestHistory.status = PointRequestStatus.INSUFFICIENT;
+			PointShortage shortage = PointShortage.of(
+				pointTransactionRequestHistory,
+				requestPoint - wallet.checkBalance(),
+				wallet.checkBalance());
+			pointTransactionRequestHistory.addShortage(shortage);
+		}
+
+		return pointTransactionRequestHistory;
+	}
+
+	private void addShortage(PointShortage shortage) {
+		this.pointShortage = shortage;
+	}
+
 
 	public void success() {
 		if (this.status != PointRequestStatus.REQUESTED) {

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/entity/PointTransactionRequestHistory.java
@@ -26,10 +26,10 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 
 @Table(name = "p_point_transaction_request_history",
-	uniqueConstraints = @UniqueConstraint(
-		name = "uk_idempotency_key",
-		columnNames = "idempotency_key"
-	)
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_idempotency_key", columnNames = "idempotency_key"),
+		@UniqueConstraint(name = "uk_ref_id_request_type", columnNames = {"ref_id", "request_type"})
+	}
 )
 @Entity
 public class PointTransactionRequestHistory extends BaseTimeEntity { // created, updated 상속 중
@@ -119,22 +119,12 @@ public class PointTransactionRequestHistory extends BaseTimeEntity { // created,
 			throw new IllegalArgumentException("주문 금액은 1원 이상이어야 합니다.");
 		}
 
-
 		PointTransactionRequestHistory pointTransactionRequestHistory = new PointTransactionRequestHistory();
 		pointTransactionRequestHistory.wallet = wallet;
 		pointTransactionRequestHistory.requestPoint = requestPoint;
 		pointTransactionRequestHistory.refId = refId;
 		pointTransactionRequestHistory.requestType = PointRequestType.ORDER_PAYMENT;
 		pointTransactionRequestHistory.status = PointRequestStatus.REQUESTED;
-
-		if (wallet.checkBalance() < requestPoint) {
-			pointTransactionRequestHistory.status = PointRequestStatus.INSUFFICIENT;
-			PointShortage shortage = PointShortage.of(
-				pointTransactionRequestHistory,
-				requestPoint - wallet.checkBalance(),
-				wallet.checkBalance());
-			pointTransactionRequestHistory.addShortage(shortage);
-		}
 
 		return pointTransactionRequestHistory;
 	}
@@ -156,6 +146,15 @@ public class PointTransactionRequestHistory extends BaseTimeEntity { // created,
 			throw new WalletException(INVALID_STATUS_TRANSITION);
 		}
 		this.status = PointRequestStatus.FAILED;
+	}
+
+	public void insufficient() {
+		PointShortage shortage = PointShortage.of(
+			this,
+			this.requestPoint - wallet.checkBalance(),
+			wallet.checkBalance());
+		this.addShortage(shortage);
+		this.status = PointRequestStatus.INSUFFICIENT;
 	}
 
 	public boolean isSuccess() {

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/enums/PointRequestStatus.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/enums/PointRequestStatus.java
@@ -3,7 +3,8 @@ package com.trustamarket.walletservice.wallet.domain.enums;
 public enum PointRequestStatus {
 	REQUESTED,
 	SUCCESS,
-	FAILED;
+	FAILED,
+	INSUFFICIENT;
 
 	public static PointRequestStatus from(String value) {
 		if (value == null) {

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/enums/PointRequestType.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/enums/PointRequestType.java
@@ -2,5 +2,6 @@ package com.trustamarket.walletservice.wallet.domain.enums;
 
 public enum PointRequestType {
 	CHARGE,
-	PAYOUT
+	PAYOUT,
+	ORDER_PAYMENT
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointShortageRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointShortageRepository.java
@@ -1,0 +1,10 @@
+package com.trustamarket.walletservice.wallet.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.trustamarket.walletservice.wallet.domain.entity.PointShortage;
+
+public interface PointShortageRepository {
+	Optional<PointShortage> findByOrderId(UUID orderId);
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRepository.java
@@ -20,4 +20,5 @@ public interface PointTransactionRepository {
 
 	boolean existsByRefIdAndPointTxType(UUID orderId, PointTxType pointTxType);
 	Optional<PointTransaction> findByOrderIdAndWalletIdAndPointTxType(UUID orderId, UUID walletId, PointTxType pointTxType);
+	Optional<PointTransaction> findByRefIdAndPointTxType(UUID refId, PointTxType pointTxType);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRequestHistoryRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRequestHistoryRepository.java
@@ -10,6 +10,6 @@ public interface PointTransactionRequestHistoryRepository {
 	PointTransactionRequestHistory save(PointTransactionRequestHistory chargeTx);
 	Optional<PointTransactionRequestHistory> findById(UUID pointTxHistoryId);
 	Optional<PointTransactionRequestHistory> findByIdempotencyKey(String IdempotencyKey); //멱등키 저장 관련 고민 필요
-	Optional<PointTransactionRequestHistory> findByRefIdAndPointRequestType(UUID refId, PointRequestType pointRequestType);
+	Optional<PointTransactionRequestHistory> findByIdempotencyKeyAndRefIdAndPointRequestType(String IdempotencyKey, UUID refId, PointRequestType pointRequestType);
 	boolean existsById(UUID pointTxHistoryId);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRequestHistoryRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/domain/repository/PointTransactionRequestHistoryRepository.java
@@ -4,10 +4,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransactionRequestHistory;
+import com.trustamarket.walletservice.wallet.domain.enums.PointRequestType;
 
 public interface PointTransactionRequestHistoryRepository {
 	PointTransactionRequestHistory save(PointTransactionRequestHistory chargeTx);
 	Optional<PointTransactionRequestHistory> findById(UUID pointTxHistoryId);
 	Optional<PointTransactionRequestHistory> findByIdempotencyKey(String IdempotencyKey); //멱등키 저장 관련 고민 필요
+	Optional<PointTransactionRequestHistory> findByRefIdAndPointRequestType(UUID refId, PointRequestType pointRequestType);
 	boolean existsById(UUID pointTxHistoryId);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointShortageRepositoryImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointShortageRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.trustamarket.walletservice.wallet.infrastructure.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.trustamarket.walletservice.wallet.domain.entity.PointShortage;
+import com.trustamarket.walletservice.wallet.domain.repository.PointShortageRepository;
+import com.trustamarket.walletservice.wallet.infrastructure.persistence.jpa.PointShortageJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class PointShortageRepositoryImpl implements PointShortageRepository {
+	private final PointShortageJpaRepository pointShortageRepository;
+
+	@Override
+	public Optional<PointShortage> findByOrderId(UUID orderId) {
+		return pointShortageRepository.findByOrderId(orderId);
+	}
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRepositoryImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRepositoryImpl.java
@@ -52,4 +52,9 @@ public class PointTransactionRepositoryImpl implements PointTransactionRepositor
 	public Optional<PointTransaction> findByOrderIdAndWalletIdAndPointTxType(UUID orderId, UUID walletId, PointTxType pointTxType) {
 		return pointTransactionRepository.findByOrderIdAndWalletIdAndPointTxType(orderId, walletId, pointTxType);
 	}
+
+	@Override
+	public Optional<PointTransaction> findByRefIdAndPointTxType(UUID refId, PointTxType pointTxType) {
+		return pointTransactionRepository.findByRefIdAndPointTxType(refId, pointTxType);
+	}
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRequestHistoryRepositoryImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRequestHistoryRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransactionRequestHistory;
+import com.trustamarket.walletservice.wallet.domain.enums.PointRequestType;
 import com.trustamarket.walletservice.wallet.domain.repository.PointTransactionRequestHistoryRepository;
 import com.trustamarket.walletservice.wallet.infrastructure.persistence.jpa.PointTransactionRequestHistoryJpaRepository;
 
@@ -29,6 +30,12 @@ public class PointTransactionRequestHistoryRepositoryImpl implements PointTransa
 	@Override
 	public Optional<PointTransactionRequestHistory> findByIdempotencyKey(String IdempotencyKey) {
 		return pointTransactionRequestHistoryRepository.findByIdempotencyKey(IdempotencyKey);
+	}
+
+	@Override
+	public Optional<PointTransactionRequestHistory> findByRefIdAndPointRequestType(UUID refId,
+		PointRequestType pointRequestType) {
+		return pointTransactionRequestHistoryRepository.findByRefIdAndRequestType(refId, pointRequestType);
 	}
 
 	@Override

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRequestHistoryRepositoryImpl.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/PointTransactionRequestHistoryRepositoryImpl.java
@@ -33,9 +33,9 @@ public class PointTransactionRequestHistoryRepositoryImpl implements PointTransa
 	}
 
 	@Override
-	public Optional<PointTransactionRequestHistory> findByRefIdAndPointRequestType(UUID refId,
-		PointRequestType pointRequestType) {
-		return pointTransactionRequestHistoryRepository.findByRefIdAndRequestType(refId, pointRequestType);
+	public Optional<PointTransactionRequestHistory> findByIdempotencyKeyAndRefIdAndPointRequestType(
+		String idempotencyKey, UUID refId, PointRequestType pointRequestType) {
+		return pointTransactionRequestHistoryRepository.findByIdempotencyKeyAndRefIdAndRequestType(idempotencyKey, refId, pointRequestType);
 	}
 
 	@Override

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointShortageJpaRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointShortageJpaRepository.java
@@ -1,0 +1,16 @@
+package com.trustamarket.walletservice.wallet.infrastructure.persistence.jpa;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.trustamarket.walletservice.wallet.domain.entity.PointShortage;
+
+public interface PointShortageJpaRepository extends JpaRepository<PointShortage, UUID> {
+
+	@Query("SELECT s FROM PointShortage s JOIN FETCH s.requestHistory rh WHERE rh.refId = :orderId")
+	Optional<PointShortage> findByOrderId(@Param("orderId") UUID orderId);
+}

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionJpaRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionJpaRepository.java
@@ -54,10 +54,17 @@ public interface PointTransactionJpaRepository extends JpaRepository<PointTransa
 	boolean existsByRefIdAndPointTxType(@Param("refId") UUID refId, @Param("pointTxType") PointTxType pointTxType);
 
 	@Query("""
-    SELECT pt FROM PointTransaction pt 
+    SELECT pt FROM PointTransaction pt
     WHERE pt.ref.refId = :orderId
       AND pt.wallet.walletId = :walletId
       AND pt.pointTxType = :pointTxType
     """)
 	Optional<PointTransaction> findByOrderIdAndWalletIdAndPointTxType(@Param("orderId") UUID orderId, @Param("walletId") UUID walletId, @Param("pointTxType")PointTxType pointTxType);
+
+	@Query("""
+    SELECT pt FROM PointTransaction pt
+    WHERE pt.ref.refId = :refId
+      AND pt.pointTxType = :pointTxType
+    """)
+	Optional<PointTransaction> findByRefIdAndPointTxType(@Param("refId") UUID refId, @Param("pointTxType") PointTxType pointTxType);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionRequestHistoryJpaRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionRequestHistoryJpaRepository.java
@@ -6,7 +6,9 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.trustamarket.walletservice.wallet.domain.entity.PointTransactionRequestHistory;
+import com.trustamarket.walletservice.wallet.domain.enums.PointRequestType;
 
 public interface PointTransactionRequestHistoryJpaRepository extends JpaRepository<PointTransactionRequestHistory, UUID> {
 	Optional<PointTransactionRequestHistory> findByIdempotencyKey(String IdempotencyKey);
+	Optional<PointTransactionRequestHistory> findByRefIdAndRequestType(UUID refId, PointRequestType requestType);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionRequestHistoryJpaRepository.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/infrastructure/persistence/jpa/PointTransactionRequestHistoryJpaRepository.java
@@ -10,5 +10,5 @@ import com.trustamarket.walletservice.wallet.domain.enums.PointRequestType;
 
 public interface PointTransactionRequestHistoryJpaRepository extends JpaRepository<PointTransactionRequestHistory, UUID> {
 	Optional<PointTransactionRequestHistory> findByIdempotencyKey(String IdempotencyKey);
-	Optional<PointTransactionRequestHistory> findByRefIdAndRequestType(UUID refId, PointRequestType requestType);
+	Optional<PointTransactionRequestHistory> findByIdempotencyKeyAndRefIdAndRequestType(String IdempotencyKey, UUID refId, PointRequestType requestType);
 }

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
@@ -56,7 +56,7 @@ public class WalletInternalController {
 
 	@PatchMapping("/usages")
 	public ResponseEntity<CommonResponse<UseWalletResponse>> usePoint (@Valid @RequestBody UseWalletRequest request) {
-		UseWalletResult result = walletCommandService.usePoint(new UseWalletCommand(request.orderId(), request.buyerId(), request.totalAmount()));
+		UseWalletResult result = walletCommandService.usePoint(new UseWalletCommand(request.idempotencyKey(), request.orderId(), request.buyerId(), request.totalAmount()));
 		
 		return ResponseEntity.ok(CommonResponse.of(HttpStatus.OK.value(), new UseWalletResponse(result.balance(), result.shortage())));
 	}

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
@@ -6,10 +6,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.trustamarket.common.response.CommonResponse;
@@ -47,8 +47,8 @@ public class WalletInternalController {
 			.body(CommonResponse.of(HttpStatus.CREATED.value(), new CreateWalletResponse(createResult.result())));
 	}
 
-	@GetMapping("/usages/{orderId}") // requestParam
-	public ResponseEntity<CommonResponse<GetPointUsageResponse>> getPointUsageTransaction(@PathVariable UUID orderId) {
+	@GetMapping("/usages") // requestParam
+	public ResponseEntity<CommonResponse<GetPointUsageResponse>> getPointUsageTransaction(@RequestParam(required = true) UUID orderId) {
 		GetPointUsageResult result = walletQueryService.getPointUsageTx(orderId);
 		return ResponseEntity.ok(CommonResponse.of(HttpStatus.OK.value(), GetPointUsageResponse.from(result)));
 	}

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/WalletInternalController.java
@@ -1,8 +1,12 @@
 package com.trustamarket.walletservice.wallet.presentation;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,13 +18,16 @@ import com.trustamarket.walletservice.wallet.application.dto.command.ChargeCompl
 import com.trustamarket.walletservice.wallet.application.dto.command.UseWalletCommand;
 import com.trustamarket.walletservice.wallet.application.dto.command.WithdrawCompleteCommand;
 import com.trustamarket.walletservice.wallet.application.dto.result.CreateWalletResult;
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointUsageResult;
 import com.trustamarket.walletservice.wallet.application.dto.result.UseWalletResult;
+import com.trustamarket.walletservice.wallet.application.query.WalletQueryService;
 import com.trustamarket.walletservice.wallet.domain.enums.PointRequestStatus;
 import com.trustamarket.walletservice.wallet.presentation.dto.request.ChargeCompleteRequest;
 import com.trustamarket.walletservice.wallet.presentation.dto.request.CreateWalletRequest;
 import com.trustamarket.walletservice.wallet.presentation.dto.request.UseWalletRequest;
 import com.trustamarket.walletservice.wallet.presentation.dto.request.WithdrawCompleteRequest;
 import com.trustamarket.walletservice.wallet.presentation.dto.response.CreateWalletResponse;
+import com.trustamarket.walletservice.wallet.presentation.dto.response.GetPointUsageResponse;
 import com.trustamarket.walletservice.wallet.presentation.dto.response.UseWalletResponse;
 
 import jakarta.validation.Valid;
@@ -31,6 +38,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/internal/v1/wallets")
 public class WalletInternalController {
 	private final WalletCommandService walletCommandService;
+	private final WalletQueryService walletQueryService;
 
 	@PostMapping
 	public ResponseEntity<CommonResponse<CreateWalletResponse>> createWallet(@RequestBody CreateWalletRequest request) {
@@ -38,6 +46,13 @@ public class WalletInternalController {
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(CommonResponse.of(HttpStatus.CREATED.value(), new CreateWalletResponse(createResult.result())));
 	}
+
+	@GetMapping("/usages/{orderId}") // requestParam
+	public ResponseEntity<CommonResponse<GetPointUsageResponse>> getPointUsageTransaction(@PathVariable UUID orderId) {
+		GetPointUsageResult result = walletQueryService.getPointUsageTx(orderId);
+		return ResponseEntity.ok(CommonResponse.of(HttpStatus.OK.value(), GetPointUsageResponse.from(result)));
+	}
+
 
 	@PatchMapping("/usages")
 	public ResponseEntity<CommonResponse<UseWalletResponse>> usePoint (@Valid @RequestBody UseWalletRequest request) {

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/UseWalletRequest.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/request/UseWalletRequest.java
@@ -7,6 +7,8 @@ import jakarta.validation.constraints.Positive;
 
 public record UseWalletRequest(
 	@NotNull
+	UUID idempotencyKey, // 결제 요청 ID = idempotencyKey 를 함께 보내줌
+	@NotNull
 	UUID orderId,
 	@NotNull
 	UUID buyerId,

--- a/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/response/GetPointUsageResponse.java
+++ b/src/main/java/com/trustamarket/walletservice/wallet/presentation/dto/response/GetPointUsageResponse.java
@@ -1,0 +1,23 @@
+package com.trustamarket.walletservice.wallet.presentation.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.trustamarket.walletservice.wallet.application.dto.result.GetPointUsageResult;
+
+public record GetPointUsageResponse(UUID orderId, String result,
+								 Long amount, Long balance, Long shortage,
+								 Instant deductedAt)
+{
+
+	public static GetPointUsageResponse from(GetPointUsageResult pointUsageResult) {
+		return new GetPointUsageResponse(
+			pointUsageResult.orderId(),
+			pointUsageResult.walletUsageStatus().name(),
+			pointUsageResult.amount(),
+			pointUsageResult.balance(),
+			pointUsageResult.shortage(),
+			pointUsageResult.deductedAt()
+		);
+	}
+}

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,3 +2,6 @@ databaseChangeLog:
   - include:
       file: sql/V001__init.sql
       relativeToChangelogFile: true
+  - include:
+      file: sql/V004__add_point_shortage.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/sql/V004__add_point_shortage.sql
+++ b/src/main/resources/db/changelog/sql/V004__add_point_shortage.sql
@@ -4,6 +4,11 @@
 ALTER TABLE p_point_transaction_request_history
     ADD COLUMN IF NOT EXISTS ref_id UUID;
 
+--changeset ihyein:2
+ALTER TABLE p_point_transaction_request_history
+    ADD CONSTRAINT uk_ref_id_request_type UNIQUE (ref_id, request_type);
+
+--changeset ihyein:3
 CREATE TABLE IF NOT EXISTS p_point_shortage (
     id                                    UUID        PRIMARY KEY,
     point_transaction_request_history_id  UUID        NOT NULL UNIQUE,

--- a/src/main/resources/db/changelog/sql/V004__add_point_shortage.sql
+++ b/src/main/resources/db/changelog/sql/V004__add_point_shortage.sql
@@ -6,7 +6,9 @@ ALTER TABLE p_point_transaction_request_history
 
 --changeset ihyein:2
 ALTER TABLE p_point_transaction_request_history
-    ADD CONSTRAINT uk_ref_id_request_type UNIQUE (ref_id, request_type);
+DROP CONSTRAINT uk_idempotency_key,
+    ADD CONSTRAINT uk_idempotency_key_ref_id_request_type
+        UNIQUE (idempotency_key, ref_id, request_type);
 
 --changeset ihyein:3
 CREATE TABLE IF NOT EXISTS p_point_shortage (

--- a/src/main/resources/db/changelog/sql/V004__add_point_shortage.sql
+++ b/src/main/resources/db/changelog/sql/V004__add_point_shortage.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+ALTER TABLE p_point_transaction_request_history
+    ADD COLUMN IF NOT EXISTS ref_id UUID;
+
+CREATE TABLE IF NOT EXISTS p_point_shortage (
+    id                                    UUID        PRIMARY KEY,
+    point_transaction_request_history_id  UUID        NOT NULL UNIQUE,
+    shortage                              BIGINT      NOT NULL,
+    CONSTRAINT fk_shortage_request_history
+        FOREIGN KEY (point_transaction_request_history_id)
+        REFERENCES p_point_transaction_request_history(point_transaction_request_history_id)
+);

--- a/src/main/resources/db/changelog/sql/V004__add_point_shortage.sql
+++ b/src/main/resources/db/changelog/sql/V004__add_point_shortage.sql
@@ -1,5 +1,6 @@
 --liquibase formatted sql
 
+--changeset ihyein:1
 ALTER TABLE p_point_transaction_request_history
     ADD COLUMN IF NOT EXISTS ref_id UUID;
 
@@ -7,6 +8,7 @@ CREATE TABLE IF NOT EXISTS p_point_shortage (
     id                                    UUID        PRIMARY KEY,
     point_transaction_request_history_id  UUID        NOT NULL UNIQUE,
     shortage                              BIGINT      NOT NULL,
+    balance                               BIGINT      NOT NULL,
     CONSTRAINT fk_shortage_request_history
         FOREIGN KEY (point_transaction_request_history_id)
         REFERENCES p_point_transaction_request_history(point_transaction_request_history_id)


### PR DESCRIPTION


## 🌱 설명

- orderId로 지갑 결제 결과를 조회하는 내부 API 추가.
- 잔액 부족 거절 이력을 p_point_transaction_request_history와 p_point_shortage에 기록하고, DEDUCTED/INSUFFICIENT/NOT_FOUND로 응답.

## 📌 관련 이슈

close #65

## ✅ 주요 변경 사항

-
-
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문별 포인트 사용 내역 조회 추가(금액, 잔액, 부족분, 처리시각 포함) 및 응답 DTO 추가
  * 내부 API 엔드포인트 추가: GET /internal/v1/wallets/usages?orderId=...
  * 멱등성 키(idempotencyKey) 기반 중복 요청 처리 및 즉시 성공/부족 응답 처리
  * 포인트 결제 시도 기록 저장 및 부족(INISUFFICIENT) 상태 추적 추가
* **데이터베이스**
  * 부족 정보 저장을 위한 스키마 및 마이그레이션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->